### PR TITLE
move return statement at the bottom out of for loop block

### DIFF
--- a/ZenPacks/zenoss/OpenStackInfrastructure/modeler/plugins/zenoss/cmd/linux/openstack/inifiles.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/modeler/plugins/zenoss/cmd/linux/openstack/inifiles.py
@@ -278,4 +278,4 @@ class inifiles(PythonPlugin):
                 if ini:
                     data['set_neutron_ini'][(filename, section, option)] = self.ini_get(device, filename, ini, section, option)
 
-            return ObjectMap({'setApplyDataMapToOpenStackInfrastructureEndpoint': ObjectMap(data)})
+        return ObjectMap({'setApplyDataMapToOpenStackInfrastructureEndpoint': ObjectMap(data)})


### PR DESCRIPTION
the return statement was previously within a for loop block. This fix just move the statement out of it.