### PR TITLE
Add neutron feature tag to meta.zcml

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -400,6 +400,7 @@ Provides linkage between OpenStackInfrastrcuture components and relevant integra
 
 ;2.1.1
 * Various bug fixes
+* Add meta.zcml feature tags for Neutron Integration
 
 ;2.1.0
 * Added Neutron network components

--- a/ZenPacks/zenoss/OpenStackInfrastructure/meta.zcml
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/meta.zcml
@@ -1,0 +1,6 @@
+<configure xmlns="http://namespaces.zope.org/meta">
+
+    <!-- OpenStack Integration features -->
+    <provides feature="openstack_neutron_integration" />
+
+</configure>


### PR DESCRIPTION
Fixes  ZEN-21744 (in part)
* For older OSI relases, we can use this to check for ML2 plugins at load time.
* Zenpacks needing to test against this will need to be modified.