### PR TITLE
ZEN-21977: wrap api call in try/except in case

### DIFF
--- a/ZenPacks/zenoss/OpenStackInfrastructure/modeler/plugins/zenoss/OpenStackInfrastructure.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/modeler/plugins/zenoss/OpenStackInfrastructure.py
@@ -275,8 +275,14 @@ class OpenStackInfrastructure(PythonPlugin):
 
         results['quotas'] = {}
         for tenant in results['tenants']:
-            result = yield client.cinder_quotas(tenant=tenant['id'].encode('ascii', 'ignore'), usage=False)
-            results['quotas'][tenant['id']] = result['quota_set']
+            try:
+                result = yield client.cinder_quotas(tenant=tenant['id'].encode(
+                    'ascii', 'ignore'), usage=False)
+            except Exception, e:
+                log.warn("Unable to obtain quotas for %s. Error message: %s" %
+                         (tenant['name'], e.message))
+            else:
+                results['quotas'][tenant['id']] = result['quota_set']
 
         returnValue(results)
 


### PR DESCRIPTION
           server does not provide quota API.

This problem occurs when the OpenStack host does not provide some API service. In this case, the quota service.