### PR TITLE
Implement canonical hostname detection.

### DIFF
--- a/ZenPacks/zenoss/OpenStackInfrastructure/lib/HostMap.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/lib/HostMap.py
@@ -10,7 +10,7 @@
 ###########################################################################
 
 import logging
-log = logging.getLogger('osi.lib.OsiDnsHost')
+log = logging.getLogger('osi.lib.HostMap')
 logging.basicConfig(level=logging.DEBUG)
 
 import socket
@@ -73,14 +73,14 @@ def resolve_names_with_retries(names, retries=2):
 
 
 # ==============================================================================
-class OsiDnsError(Exception):
+class hostMapError(Exception):
     """Parent class of all exceptions raised by api clients."""
     pass
 
 
-class OsiHostResolver(object):
+class HostResolver(object):
     """
-    Create a host-ip map that can be referenced later as an object.
+    Create a host-ip relationship that can be referenced later as an object.
     """
     def __init__(self):
         self.resolved_hostnames = {}
@@ -99,15 +99,15 @@ class OsiHostResolver(object):
 
         # Force addition of map: mapping must be a dict of form {name: ip}
         if self.locked:
-            log.warn("Denied: add_hostnames() to locked OsiHostResolver")
+            log.warn("Denied: add_hostnames() to locked HostResolver")
         else:
             self.resolved_hostnames.update(mapping)
 
     @inlineCallbacks
     def bulk_update_names(self, hostnames):
-        # Resolve and update map from a list of names.
+        # Resolve and update from a list of names.
         if self.locked:
-            log.warn("Denied: add hostnames to locked OsiHostResolver")
+            log.warn("Denied: add hostnames to locked HostResolver")
             return
 
         # Ensure that all hostnames are valid
@@ -125,7 +125,7 @@ class OsiHostResolver(object):
     def add_hostname(self, name, ip=None):
         # Add single hostname-ip pair. Ensure valid format
         if self.locked:
-            log.warn("Denied: add hostname:ip pair to locked OsiHostResolver")
+            log.warn("Denied: add hostname:ip pair to locked HostResolver")
             return
         if not isip(ip):
             log.ERROR("Denied: Can't add invalid IP: %s", ip)
@@ -154,10 +154,10 @@ class OsiHostResolver(object):
         return self.resolved_hostnames
 
 
-class OsiDnsHost(object):
+class HostMap(object):
     '''
-    OsiDnsHost represents resolvable hosts in the OSI cluster.
-    It requires a valid OsiHostResolver instance object in order to get
+    HostMap represents known hosts in the OSI cluster.
+    It requires a valid HostResolver instance object in order to get
     pre-resolved IP addresses. When fully populated, objects have:
     @locked: lock host from updates
     @ip: The IP address
@@ -167,7 +167,7 @@ class OsiDnsHost(object):
 
     def __new__(cls, ip=None, hostname=None, canonical=None):
         if not (ip or hostname):
-            log.error("Missing IP and Hostname for OsiDnsHost creation!")
+            log.error("Missing IP and Hostname for HostMap creation!")
             return
         else:
             return object.__new__(cls)
@@ -175,16 +175,16 @@ class OsiDnsHost(object):
     def __init__(self, ip=None, hostname=None, canonical=None):
 
         if not (ip or hostname):
-            log.error("Missing IP or Hostname for OsiDnsHost creation!")
-            # raise Exception("Missing IP or Hostname for OsiDnsHost creation!")
+            log.error("Missing IP or Hostname for HostMap creation!")
+            # raise Exception("Missing IP or Hostname for HostMap creation!")
 
         self.locked = False
 
         if not ip:
-            log.debug("Missing IP for OsiDnsHost creation. Check DNS")
+            log.debug("Missing IP for HostMap creation. Check DNS")
             self.ip = None
         elif not isip(ip):
-            log.warn("Bad IP in OsiDnsHost creation!")
+            log.warn("Bad IP in HostMap creation!")
             self.ip = None
         else:
             self.ip = ip
@@ -198,21 +198,21 @@ class OsiDnsHost(object):
             self.canonical_hostname = canonical
 
     def __eq__(self, other):
-        # Allows set(OsiDnsHost) to determine equailty based on contents
-        if isinstance(other, OsiDnsHost):
+        # Allows set(HostMap) to determine equailty based on contents
+        if isinstance(other, HostMap):
             return self.ip == other.ip and self.hostnames == other.hostnames
         return False
 
     def __ne__(self, other):
-        # Allows set(OsiDnsHost) to determine equailty based on contents
+        # Allows set(HostMap) to determine equailty based on contents
         return (not self.__eq__(other))
 
     def __repr__(self):
-        # Allows set(OsiDnsHost) to determine equailty based on contents
+        # Allows set(HostMap) to determine equailty based on contents
         return 'H({s.ip!r}, {s.hostnames!r})'.format(s=self)
 
     def __hash__(self):
-        # Allows set(OsiDnsHost) to determine equailty based on contents
+        # Allows set(HostMap) to determine equailty based on contents
         return hash(repr(self))
 
     def lock(self):
@@ -239,7 +239,7 @@ class OsiDnsHost(object):
         # unique hostname. Take the first host in alphabetical order
         # Use cached value if available
         if not self.hostnames:
-            log.warn("get_canonical: No hostnames for OsiDnsHost %s", self.ip)
+            log.warn("get_canonical: No hostnames for HostMap %s", self.ip)
             return
 
         if self.canonical_hostname:
@@ -260,7 +260,7 @@ class OsiDnsHost(object):
         # unique hostname. Typically we will take the most fully qualified
         # domain name that is found.
         if self.locked:
-            log.warn("Won't update canonical on locked OsiDnsHost %s", self.ip)
+            log.warn("Won't update canonical on locked HostMap %s", self.ip)
             return
 
         self.canonical_hostname = None
@@ -269,7 +269,7 @@ class OsiDnsHost(object):
     def add_hostname(self, hostname, ip=None):
         # NOTE: We don't update self.canonica_hostname here. Must do manually.
         if self.locked:
-            log.warn("Won't add %s to locked OsiDnsHost %s", hostname, self.ip)
+            log.warn("Won't add %s to locked HostMap %s", hostname, self.ip)
             return
 
         # If hostname is in hostnames, pass, else check IP: add it
@@ -299,7 +299,7 @@ class OsiDnsHost(object):
         # Add hostnames in batch.
         # We blindly assume that these hostnames are valid for this host.
         if self.locked:
-            log.warn("Won't add hosts to locked OsiDnsHost %s", self.ip)
+            log.warn("Won't add hosts to locked HostMap %s", self.ip)
             return
 
         if isinstance(hostnames, (list, set)):
@@ -314,10 +314,10 @@ class OsiDnsHost(object):
         if hostname.lower() in self.hostnames:
             return True
 
-    def is_equal(self, dnsHost):
+    def is_equal(self, hostMap):
         # This is comparison of two objects.
         # NOTE: Comparison of hostnames is suspect: Why can't they differ?
-        if dnsHost.get_ip() in self.ip and dnsHost.hostnames == self.hostnames:
+        if hostMap.get_ip() in self.ip and hostMap.hostnames == self.hostnames:
             return True
 
     def valid_hostname_ip(self):
@@ -338,20 +338,20 @@ class OsiDnsHost(object):
             return True
 
 
-class OsiHostGroup(object):
+class HostGroup(object):
     '''
-    Class that contains a collection of OsiDnsHost objects.
+    Class that contains a collection of HostMap objects.
     '''
 
     def __init__(self, hostResolver=None):
-        if not isinstance(hostResolver, OsiHostResolver):
-            raise OsiDnsError("Invalid OsiHostResolver instance for OsiHostGroup")
+        if not isinstance(hostResolver, HostResolver):
+            raise hostMapError("Invalid HostResolver instance for HostGroup")
         self.hostResolver = hostResolver
         self.hosts = set()
 
     def update_Resolver(self, hostResolver):
-        if not isinstance(hostResolver, OsiHostResolver):
-            raise OsiDnsError("Invalid OsiHostResolver instance for OsiHostGroup")
+        if not isinstance(hostResolver, HostResolver):
+            raise hostMapError("Invalid HostResolver instance for HostGroup")
         else:
             self.hostResolver = hostResolver
 
@@ -393,8 +393,8 @@ class OsiHostGroup(object):
 
     def has_equivalent(self, osiHost):
         # Boolean: Test if self has equiv osiHost buy value
-        if not isinstance(osiHost, OsiDnsHost):
-            log.warn("host is non-OsiDnsHost. Unable to compare.")
+        if not isinstance(osiHost, HostMap):
+            log.warn("host is non-HostMap. Unable to compare.")
             return
 
         # Find the proper host in hosts set given host_or_ip
@@ -405,8 +405,8 @@ class OsiHostGroup(object):
 
     def is_subset_host(self, osiHost):
         # If osiHost is subset of some host in set, return True
-        if not isinstance(osiHost, OsiDnsHost):
-            log.warn("host is non-OsiDnsHost. Unable to compare.")
+        if not isinstance(osiHost, HostMap):
+            log.warn("host is non-HostMap. Unable to compare.")
             return
 
         for host in self.hosts:
@@ -417,8 +417,8 @@ class OsiHostGroup(object):
 
     def get_subset_host(self, osiHost):
         # Return host that is subset of this host
-        if not isinstance(osiHost, OsiDnsHost):
-            log.warn("host is non-OsiDnsHost. Unable to compare.")
+        if not isinstance(osiHost, HostMap):
+            log.warn("host is non-HostMap. Unable to compare.")
             return
 
         for host in self.hosts:
@@ -441,9 +441,9 @@ class OsiHostGroup(object):
         return False
 
     def add_host(self, osiHost):
-        # Add OsiDnsHost instance to set, but only if unique. Otherwise merge.
-        if not isinstance(osiHost, OsiDnsHost):
-            log.warn("Can't add an non OsiDnsHost object")
+        # Add HostMap instance to set, but only if unique. Otherwise merge.
+        if not isinstance(osiHost, HostMap):
+            log.warn("Can't add an non HostMap object")
             return
 
         if self.has_equivalent(osiHost) or self.is_subset_host(osiHost):
@@ -458,9 +458,9 @@ class OsiHostGroup(object):
             self.hosts.add(osiHost)
 
     def remove_host(self, osiHost):
-        # Delete OsiDnsHost object
-        if not isinstance(osiHost, OsiDnsHost):
-            log.debug("Can't remove an non OsiDnsHost object")
+        # Delete HostMap object
+        if not isinstance(osiHost, HostMap):
+            log.debug("Can't remove an non HostMap object")
             return
 
         self.hosts.remove(osiHost)
@@ -485,22 +485,22 @@ class OsiHostGroup(object):
 
         # If new host is an IP, add it as such
         if isip(name):
-            self.add_host(OsiDnsHost(ip=name))
+            self.add_host(HostMap(ip=name))
             return
 
         # Host is new hostname, so add it as such. IP can be None:
         ip = self.hostResolver.getIpFromName(name)
         if ip:
-            osiHost = OsiDnsHost(ip)
+            osiHost = HostMap(ip)
             osiHost.add_hostname(name)
         else:
             log.warn("Adding host %s to a baren (missing ip) host!", name)
-            osiHost = OsiDnsHost(hostname=name)
+            osiHost = HostMap(hostname=name)
 
         self.add_host(osiHost)
 
     def add_hostnames(self, hostnames):
-        # Add an OsiDnsHost for each corresponding name in hostnames
+        # Add an HostMap for each corresponding name in hostnames
         for host in hostnames:
             self.add_hostname(host)
 # ==============================================================================

--- a/ZenPacks/zenoss/OpenStackInfrastructure/lib/OsiDnsHost.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/lib/OsiDnsHost.py
@@ -1,0 +1,506 @@
+###########################################################################
+# This program is part of Zenoss Core, an open source monitoring platform.
+# Copyright (C) 2014, Zenoss Inc.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 or (at your
+# option) any later version as published by the Free Software Foundation.
+#
+# For complete information please visit: http://www.zenoss.com/oss/
+###########################################################################
+
+import logging
+log = logging.getLogger('osi.lib.OsiDnsHost')
+logging.basicConfig(level=logging.DEBUG)
+
+import socket
+from twisted.internet.defer import inlineCallbacks, returnValue
+from twisted.internet import reactor
+
+from ZenPacks.zenoss.OpenStackInfrastructure.lib.domains import (
+                                                        get_dominant_domain,
+                                                        extract_valid_hostname,
+                                                        )
+from Products.ZenUtils.Utils import prepId
+from Products.ZenUtils.IpUtil import isip
+
+
+@inlineCallbacks
+def resolve_name(name):
+    ## If you have an IP already, return it.
+    # if isip(name):
+    #    returnValue((name, name))
+    ip = yield reactor.resolve(name)
+    returnValue((name, ip))
+
+
+@inlineCallbacks
+def resolve_names(names):
+    """Resolve names to IP addresses in parallel.
+    Names must be an iterable of names.
+
+    Example return value:
+
+        {
+            'example.com': '192.168.1.2',
+            'www.google.com': '8.7.6.5',
+            'doesntexist': None,
+        }
+    """
+    from twisted.internet.defer import DeferredList
+    results = yield DeferredList(
+        [resolve_name(n) for n in names],
+        consumeErrors=True)
+
+    result_map = {n: None for n in names}
+    for success, result in results:
+        if success:
+            result_map[result[0]] = result[1]
+
+    returnValue(result_map)
+
+
+@inlineCallbacks
+def resolve_names_with_retries(names, retries=2):
+    result_map = {n: None for n in names}
+    for i in range(retries):
+        todo = [n for n in names if not result_map.get(n)]
+        if todo:
+            results = yield resolve_names(todo)
+            result_map.update(results)
+
+    returnValue(result_map)
+
+
+# ==============================================================================
+class OsiDnsError(Exception):
+    """Parent class of all exceptions raised by api clients."""
+    pass
+
+
+class OsiHostResolver(object):
+    """
+    Create a host-ip map that can be referenced later as an object.
+    """
+    def __init__(self):
+        self.resolved_hostnames = {}
+        self.locked = False
+
+    def lock(self):
+        self.locked = True
+
+    def unlock(self):
+        self.locked = False
+
+    def add_hostnames(self, mapping):
+
+        # Ensure all hostname keys are valid
+        mapping = dict((extract_valid_hostname(k), v) for k, v in mapping.iteritems())
+
+        # Force addition of map: mapping must be a dict of form {name: ip}
+        if self.locked:
+            log.warn("Denied: add_hostnames() to locked OsiHostResolver")
+        else:
+            self.resolved_hostnames.update(mapping)
+
+    @inlineCallbacks
+    def bulk_update_names(self, hostnames):
+        # Resolve and update map from a list of names.
+        if self.locked:
+            log.warn("Denied: add hostnames to locked OsiHostResolver")
+            return
+
+        # Ensure that all hostnames are valid
+        hostnames = set(extract_valid_hostname(h) for h in hostnames)
+        resolved_map = yield resolve_names_with_retries(hostnames)
+        self.resolved_hostnames.update(resolved_map)
+
+        # If hostnames don't resolve, we still need to add them without IP
+        # because hosts resolution could be broken..
+        for host in hostnames:
+            if host not in self.resolved_hostnames:
+                log.debug("Adding hostname: %s without IP. Check DNS!", host)
+                self.resolved_hostnames.update(host = None)
+
+    def add_hostname(self, name, ip=None):
+        # Add single hostname-ip pair. Ensure valid format
+        if self.locked:
+            log.warn("Denied: add hostname:ip pair to locked OsiHostResolver")
+            return
+        if not isip(ip):
+            log.ERROR("Denied: Can't add invalid IP: %s", ip)
+            return
+
+        valid_name = extract_valid_hostname(name)
+        if not valid_name:
+            log.ERROR("Denied: Can't add invalid Hostname: %s", name)
+
+        self.resolved_hostnames[valid_name] = ip
+
+    def getIpFromName(self, hostname):
+        ip = self.resolved_hostnames.get(hostname)
+        if not ip:
+            log.debug("resolved_hostnames: Missing IP for host %s", hostname)
+        return ip
+
+    def hasIpFromName(self, name):
+        if name in self.resolved_hostnames:
+            return True
+
+    def get_ip_addresses(self):
+        return set(self.resolved_hostnames.values())
+
+    def get_resolved(self):
+        return self.resolved_hostnames
+
+
+class OsiDnsHost(object):
+    '''
+    OsiDnsHost represents resolvable hosts in the OSI cluster.
+    It requires a valid OsiHostResolver instance object in order to get
+    pre-resolved IP addresses. When fully populated, objects have:
+    @locked: lock host from updates
+    @ip: The IP address
+    @hostname: The optional hostname
+    @canonical_hostname: The hostname that represents this host, deterministic
+    '''
+
+    def __new__(cls, ip=None, hostname=None, canonical=None):
+        if not (ip or hostname):
+            log.error("Missing IP and Hostname for OsiDnsHost creation!")
+            return
+        else:
+            return object.__new__(cls)
+
+    def __init__(self, ip=None, hostname=None, canonical=None):
+
+        if not (ip or hostname):
+            log.error("Missing IP or Hostname for OsiDnsHost creation!")
+            # raise Exception("Missing IP or Hostname for OsiDnsHost creation!")
+
+        self.locked = False
+
+        if not ip:
+            log.debug("Missing IP for OsiDnsHost creation. Check DNS")
+            self.ip = None
+        elif not isip(ip):
+            log.warn("Bad IP in OsiDnsHost creation!")
+            self.ip = None
+        else:
+            self.ip = ip
+
+        self.hostnames = set()
+        if hostname:
+            self.add_hostname(hostname)
+
+        self.canonical_hostname = None
+        if canonical:
+            self.canonical_hostname = canonical
+
+    def __eq__(self, other):
+        # Allows set(OsiDnsHost) to determine equailty based on contents
+        if isinstance(other, OsiDnsHost):
+            return self.ip == other.ip and self.hostnames == other.hostnames
+        return False
+
+    def __ne__(self, other):
+        # Allows set(OsiDnsHost) to determine equailty based on contents
+        return (not self.__eq__(other))
+
+    def __repr__(self):
+        # Allows set(OsiDnsHost) to determine equailty based on contents
+        return 'H({s.ip!r}, {s.hostnames!r})'.format(s=self)
+
+    def __hash__(self):
+        # Allows set(OsiDnsHost) to determine equailty based on contents
+        return hash(repr(self))
+
+    def lock(self):
+        self.locked = True
+
+    def unlock(self):
+        self.locked = False
+
+    def get_id(self):
+        # NOTE: process information in self.hostnames in order to synthesize a
+        # unique hostname. Typically we will take the most fully qualified
+        # domain name that is found.
+        if not self.hostnames:
+            log.warn("get_id: No hostnames available")
+            return
+
+        return prepId('host-{}'.format(self.canonical_hostname))
+
+    def get_ip(self):
+        return self.ip
+
+    def get_canonical_hostname(self):
+        # NOTE: process information in self.hostnames in order to synthesize a
+        # unique hostname. Take the first host in alphabetical order
+        # Use cached value if available
+        if not self.hostnames:
+            log.warn("get_canonical: No hostnames for OsiDnsHost %s", self.ip)
+            return
+
+        if self.canonical_hostname:
+            return self.canonical_hostname
+
+        domain = get_dominant_domain(self.hostnames)
+        if not domain:
+            log.debug("Missing domain for %s: Returning first host", self.ip)
+            hosts = sorted(self.hostnames)
+            canonical = next((x for x in hosts if not isip(x)), hosts[0])
+            return canonical
+
+        host_candidates = [h for h in self.hostnames if domain in h]
+        return sorted(host_candidates)[0]
+
+    def set_canonical_hostname(self):
+        # NOTE: process information in self.hostnames in order to synthesize a
+        # unique hostname. Typically we will take the most fully qualified
+        # domain name that is found.
+        if self.locked:
+            log.warn("Won't update canonical on locked OsiDnsHost %s", self.ip)
+            return
+
+        self.canonical_hostname = None
+        self.canonical_hostname = self.get_canonical_hostname()
+
+    def add_hostname(self, hostname, ip=None):
+        # NOTE: We don't update self.canonica_hostname here. Must do manually.
+        if self.locked:
+            log.warn("Won't add %s to locked OsiDnsHost %s", hostname, self.ip)
+            return
+
+        # If hostname is in hostnames, pass, else check IP: add it
+        hostname = extract_valid_hostname(hostname)
+        if hostname in self.hostnames:
+            log.debug("add_hostname: host alreay exists!")
+            return
+
+        if not self.ip and ip:
+            log.debug("adding hostname %s, ip: %s", hostname, self.ip)
+            self.ip = ip
+            self.hostnames.add(hostname)
+            return
+
+        if ip and self.ip:
+            if self.ip == ip:
+                log.debug("adding hostname, ip: %s -> %s", hostname, self.ip)
+                self.hostnames.add(hostname)
+            else:
+                log.debug("add_hostname: IPs don't match! %s, %s for %s",
+                        self.ip, ip, hostname)
+            return
+
+        self.hostnames.add(hostname)
+
+    def update_hostnames(self, hostnames):
+        # Add hostnames in batch.
+        # We blindly assume that these hostnames are valid for this host.
+        if self.locked:
+            log.warn("Won't add hosts to locked OsiDnsHost %s", self.ip)
+            return
+
+        if isinstance(hostnames, (list, set)):
+            for host in hostnames:
+                self.add_hostname(extract_valid_hostname(host))
+
+    def has_ip(self, ip):
+        if ip == self.ip:
+            return True
+
+    def has_hostname(self, hostname):
+        if hostname.lower() in self.hostnames:
+            return True
+
+    def is_equal(self, dnsHost):
+        # This is comparison of two objects.
+        # NOTE: Comparison of hostnames is suspect: Why can't they differ?
+        if dnsHost.get_ip() in self.ip and dnsHost.hostnames == self.hostnames:
+            return True
+
+    def valid_hostname_ip(self):
+        # Check if hostname corresponds to a valid IP via socket call
+        # NOTE: socket calls are blocking; this can be slow!
+        if socket.gethostbyname(self.get_canonical_hostname()) == self.ip:
+            return True
+
+    def merge(self, osiHost):
+        # Merge 2 host objects that have same IP's
+        self.locked = False
+        if self.ip == osiHost.ip:
+            self.hostnames = osiHost.hostnames.union(self.hostnames)
+
+    def is_subset(self, osiHost):
+        # Merge 2 host objects that have like IP's
+        if self.ip == osiHost.ip and self.hostnames < osiHost.hostnames:
+            return True
+
+
+class OsiHostGroup(object):
+    '''
+    Class that contains a collection of OsiDnsHost objects.
+    '''
+
+    def __init__(self, hostResolver=None):
+        if not isinstance(hostResolver, OsiHostResolver):
+            raise OsiDnsError("Invalid OsiHostResolver instance for OsiHostGroup")
+        self.hostResolver = hostResolver
+        self.hosts = set()
+
+    def update_Resolver(self, hostResolver):
+        if not isinstance(hostResolver, OsiHostResolver):
+            raise OsiDnsError("Invalid OsiHostResolver instance for OsiHostGroup")
+        else:
+            self.hostResolver = hostResolver
+
+    def get_host_by_name_or_ip(self, thing):
+        # Determine if thing is valid ip
+        thing = extract_valid_hostname(thing)
+        if isip(thing):
+            return self.get_host_by_ip(thing)
+
+        # Find host by name only
+        host = self.get_host_by_name(thing)
+        if host:
+            return host
+
+        # Be careful: Need to convert name to ip and check again
+        ip = self.hostResolver.getIpFromName(thing)
+        if ip:
+            return self.get_host_by_ip(ip)
+
+    def get_host_by_ip(self, ip):
+        # Determine if ip is valid
+        if not isip(ip):
+            log.debug("Invalid IP: %s", ip)
+            return
+
+        # Find the proper host in hosts set given host_or_ip
+        for host in self.hosts:
+            if ip == host.get_ip():
+                return host
+
+    def get_host_by_name(self, name):
+        # Determine if name is valid
+        name = extract_valid_hostname(name)
+
+        # Find the proper host in hosts set given host_or_ip
+        for host in self.hosts:
+            if name in host.hostnames:
+                return host
+
+    def has_equivalent(self, osiHost):
+        # Boolean: Test if self has equiv osiHost buy value
+        if not isinstance(osiHost, OsiDnsHost):
+            log.warn("host is non-OsiDnsHost. Unable to compare.")
+            return
+
+        # Find the proper host in hosts set given host_or_ip
+        for host in self.hosts:
+            if osiHost.ip == host.ip and osiHost.hostnames == host.hostnames:
+                return True
+        return False
+
+    def is_subset_host(self, osiHost):
+        # If osiHost is subset of some host in set, return True
+        if not isinstance(osiHost, OsiDnsHost):
+            log.warn("host is non-OsiDnsHost. Unable to compare.")
+            return
+
+        for host in self.hosts:
+            if osiHost.is_subset(host):
+                return True
+
+        return False
+
+    def get_subset_host(self, osiHost):
+        # Return host that is subset of this host
+        if not isinstance(osiHost, OsiDnsHost):
+            log.warn("host is non-OsiDnsHost. Unable to compare.")
+            return
+
+        for host in self.hosts:
+            if osiHost.is_subset(host):
+                return host
+
+    def has_hostname(self, hostname):
+        # Boolean: Test if osiHost IP is in hosts set
+        for host in self.hosts:
+            if hostname in host.hostnames:
+                return True
+        return False
+
+    def has_ip(self, ip):
+        # Boolean: Test if osiHost IP is in hosts set
+        for host in self.hosts:
+            if host.ip == ip:
+                return True
+
+        return False
+
+    def add_host(self, osiHost):
+        # Add OsiDnsHost instance to set, but only if unique. Otherwise merge.
+        if not isinstance(osiHost, OsiDnsHost):
+            log.warn("Can't add an non OsiDnsHost object")
+            return
+
+        if self.has_equivalent(osiHost) or self.is_subset_host(osiHost):
+            log.debug("osiHost %s is Subset", osiHost)
+            return
+
+        host_subset = self.get_subset_host(osiHost)
+        if host_subset:
+            log.debug("Found subset: %s of %s", host_subset, osiHost)
+            host_subset.merge(osiHost)
+        else:
+            self.hosts.add(osiHost)
+
+    def remove_host(self, osiHost):
+        # Delete OsiDnsHost object
+        if not isinstance(osiHost, OsiDnsHost):
+            log.debug("Can't remove an non OsiDnsHost object")
+            return
+
+        self.hosts.remove(osiHost)
+
+    def update_canonical_hostnames(self):
+        # Update canaonical_hostname for all hosts
+        for host in self.hosts:
+            host.set_canonical_hostname()
+
+    def add_hostname(self, name):
+        # Add hostname if it is not already in set.
+        name = extract_valid_hostname(name)
+        if not name:
+            log.warn("Missing name for add_hostname!")
+            return
+
+        # If host already in the set, find it and return host
+        found = self.get_host_by_name_or_ip(name)
+        if found:
+            found.add_hostname(name)
+            return
+
+        # If new host is an IP, add it as such
+        if isip(name):
+            self.add_host(OsiDnsHost(ip=name))
+            return
+
+        # Host is new hostname, so add it as such. IP can be None:
+        ip = self.hostResolver.getIpFromName(name)
+        if ip:
+            osiHost = OsiDnsHost(ip)
+            osiHost.add_hostname(name)
+        else:
+            log.warn("Adding host %s to a baren (missing ip) host!", name)
+            osiHost = OsiDnsHost(hostname=name)
+
+        self.add_host(osiHost)
+
+    def add_hostnames(self, hostnames):
+        # Add an OsiDnsHost for each corresponding name in hostnames
+        for host in hostnames:
+            self.add_hostname(host)
+# ==============================================================================

--- a/ZenPacks/zenoss/OpenStackInfrastructure/lib/domains.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/lib/domains.py
@@ -1,0 +1,157 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2014, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+"""
+Utilities for DNS, domains, dominant domains, and hostname filtering
+"""
+
+from collections import Counter
+import re
+
+import logging
+log = logging.getLogger('OSI.lib.domains')
+
+
+def validate_fqdn(dn):
+    if dn.endswith('.'):
+        dn = dn[:-1]
+    if len(dn) < 1 or len(dn) > 253:
+        return False
+    ldh_re = re.compile('^[a-z\d]([a-z\d-]{0,61}[a-z\d])?$', re.IGNORECASE)
+    return all(ldh_re.match(x) for x in dn.split('.'))
+
+
+def extract_valid_hostname(host):
+    '''Return valid IP, else hostname, else ''
+       Do this by splitting each part on dot, then comparing to valid pattern.
+       Once each part is valid, re-add it into string.
+    '''
+    if not host or host.startswith('.'):
+        return
+
+    host = host.lower()
+
+    ldh_re = re.compile('^'
+                        '(?P<crud>[^a-z\d]*)'                       # crud
+                        '(?P<good>[a-z\d]([a-z\d-]{0,61}[a-z\d])?)' # good part
+                        '\.?'                                       # ending '.'
+                        '(?P<bad>[^a-z\d\-]*)'                      # illegal
+                        '.*'                                        # all else
+                        '$',
+                        re.IGNORECASE)
+    good_parts = []
+    # Split each domain component and check: if each part good, recombine
+    # Else, short-circuit and give the largest possible valide host.
+    for part in host.split('.'):
+        part_search = ldh_re.search(part)
+        if part_search:
+            if part_search.group('crud'):
+                return '.'.join(good_parts)
+            if part_search.group('good'):
+                good_parts.append(part_search.group('good'))
+            if part_search.group('bad'):
+                return '.'.join(good_parts)
+
+    newhost = '.'.join(good_parts)
+    if host != newhost:
+        log.debug('Hostname %s extracted to %s', host, newhost)
+
+    return newhost
+
+
+def extract_domainname(host):
+    '''Return valid IP, else hostname, else ''
+       Do this by splitting each part on dot, then comparing to valid pattern.
+       Once each part is valid, re-add it into string.
+    '''
+    hostname = extract_valid_hostname(host)
+    if not hostname:
+        return
+
+    domain_RX = re.compile(
+                         '^'
+                         '(?P<hostname>[a-z\d]+[a-z\d\-]*)' # Hostname part
+                         '\.'
+                         '(?P<domain>[\w\-\.]*?\w)'     # Don't be greedy
+                         '(\.localhost|\.localdomain)*' # Remove localhost etc
+                         '\.?'                          # Optional trailing dot
+                         '$',
+                         re.I
+                         )
+
+    domain_search = domain_RX.search(hostname)
+    if domain_search:
+        return domain_search.group('domain')
+
+
+def get_domains(hostnames):
+    domains = set()
+
+    for host in hostnames:
+        d = extract_domainname(host)
+        if d:
+            domains.add(d)
+
+    return domains
+
+
+def get_dominant_domain(hostnames):
+
+    if not hostnames:
+        log.debug('get_dominant_domain: No hostnames available')
+        return
+
+    hostnames = [h for h in hostnames if re.search('[a-zA-Z]', h)]
+
+    # Safety: Convert all to lowercase in set
+    hostnames = set(h.lower() for h in hostnames)
+    domains = get_domains(hostnames)
+
+    def getKey(item):
+        return item[0]
+
+    dc = Counter()
+    for d in domains:
+        dc.update(d.lower() for n in hostnames if d.lower() in n.lower())
+
+    dc_max = [x for x in dc.items() if x[1] == dc.most_common()[0][1]]
+    dc_sorted = [a for a in sorted(dc_max, key=getKey)]
+
+    if not dc_sorted:
+        log.debug('No domain names found from hosts: %s', hostnames)
+        return
+
+    dominant_domain = dc_sorted[0][0]
+
+    if '.' not in dominant_domain:
+        log.debug('Domain ({}) has single domain component'.format(dominant_domain))
+
+    return dominant_domain
+
+
+def main():
+
+    hostnames = set()
+    hostnames.add('Zrap.example.com')
+    hostnames.add('other.example.com')
+    hostnames.add('angstrom.example.com')
+    hostnames.add('this.example.com')
+    hostnames.add('other.Example.com.localhost')
+    hostnames.add('other.Junk.com')
+    hostnames.add('other.junk.com.localdomain')
+    hostnames.add('next.junk.com.localdomain')
+    hostnames.add('xxx.Crud.com')
+    hostnames.add('xxx.crud.com')
+    domain = get_dominant_domain(hostnames)
+
+    print domain
+
+if __name__ == '__main__':
+
+    main()
+#

--- a/ZenPacks/zenoss/OpenStackInfrastructure/lib/osiDnsTest.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/lib/osiDnsTest.py
@@ -1,0 +1,716 @@
+import logging
+log = logging.getLogger('osi.OsiDnsHost')
+logging.basicConfig(level=logging.DEBUG)
+
+import socket
+from twisted.internet.defer import inlineCallbacks, returnValue
+from twisted.internet import reactor
+# from twisted.names import client as names_client
+
+
+import string
+import re
+
+from os import sys, path
+sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
+
+from domains import (
+        get_dominant_domain,
+        extract_valid_hostname,
+        )
+
+
+def prepId(id, subchar='_'):
+    """
+    Make an id with valid url characters. Subs [^a-zA-Z0-9-_,.$\(\) ]
+    with subchar.  If id then starts with subchar it is removed.
+
+    @param id: user-supplied id
+    @type id: string
+    @return: valid id
+    @rtype: string
+    """
+    _prepId = re.compile(r'[^a-zA-Z0-9-_,.$\(\) ]').sub
+    _cleanend = re.compile(r"%s+$" % subchar).sub
+    if id is None:
+        raise ValueError('Ids can not be None')
+    if not isinstance(id, basestring):
+        id = str(id)
+    id = _prepId(subchar, id)
+    while id.startswith(subchar):
+        if len(id) > 1: id = id[1:]
+        else: id = "-"
+    id = _cleanend("",id)
+    id = id.lstrip(string.whitespace + '_').rstrip()
+    return str(id)
+
+
+def ipunwrap(ip):
+    """
+    Convert IP addresses from a Zope-friendly format to a real address.
+    """
+    IP_DELIM = '..'
+    INTERFACE_DELIM = '...'
+
+    if isinstance(ip, str):
+        unwrapped = ip.replace(IP_DELIM, ':')
+        return unwrapped.replace(INTERFACE_DELIM, '%')
+    return ip
+
+
+def isip(ip):
+    uIp = str(ipunwrap(ip))
+    # Twisted monkey patches socket.inet_pton on systems that have IPv6
+    # disabled and raise a ValueError instead of the expected socket.error
+    # if the passed in address is invalid.
+    try:
+        socket.inet_pton(socket.AF_INET, uIp)
+    except (socket.error, ValueError):
+        try:
+            socket.inet_pton(socket.AF_INET6, uIp)
+        except (socket.error, ValueError):
+            return False
+    return True
+
+
+@inlineCallbacks
+def resolve_name(name):
+    ## If you have an IP already, return it.
+    # if isip(name):
+    #    returnValue((name, name))
+    ip = yield reactor.resolve(name)
+    returnValue((name, ip))
+
+
+@inlineCallbacks
+def resolve_names(names):
+    """Resolve names to IP addresses in parallel.
+    Names must be an iterable of names.
+
+    Example return value:
+
+        {
+            'example.com': '192.168.1.2',
+            'www.google.com': '8.7.6.5',
+            'doesntexist': None,
+        }
+    """
+    from twisted.internet.defer import DeferredList
+    results = yield DeferredList(
+        [resolve_name(n) for n in names],
+        consumeErrors=True)
+
+    result_map = {n: None for n in names}
+    for success, result in results:
+        if success:
+            result_map[result[0]] = result[1]
+
+    returnValue(result_map)
+
+
+@inlineCallbacks
+def resolve_names_with_retries(names, retries=2):
+    result_map = {n: None for n in names}
+    for i in range(retries):
+        todo = [n for n in names if not result_map.get(n)]
+        if todo:
+            results = yield resolve_names(todo)
+            result_map.update(results)
+
+    returnValue(result_map)
+
+
+# ==============================================================================
+class OsiDnsError(Exception):
+    """Parent class of all exceptions raised by api clients."""
+    pass
+
+
+class OsiHostResolver(object):
+    """
+    Create a host-ip map that can be referenced later as an object.
+    """
+    def __init__(self):
+        self.resolved_hostnames = {}
+        self.locked = False
+
+    def lock(self):
+        self.locked = True
+
+    def unlock(self):
+        self.locked = False
+
+    def add_hostnames(self, mapping):
+
+        # Ensure all hostname keys are valid
+        mapping = dict((extract_valid_hostname(k), v) for k, v in mapping.iteritems())
+
+        # Force addition of map: mapping must be a dict of form {name: ip}
+        if self.locked:
+            log.warn("Denied: add_hostnames() to locked OsiHostResolver")
+        else:
+            self.resolved_hostnames.update(mapping)
+
+    @inlineCallbacks
+    def bulk_update_names(self, hostnames):
+        # Resolve and update map from a list of names.
+        if self.locked:
+            log.warn("Denied: add hostnames to locked OsiHostResolver")
+            return
+
+        # Ensure that all hostnames are valid
+        hostnames = set(extract_valid_hostname(h) for h in hostnames)
+        resolved_map = yield resolve_names_with_retries(hostnames)
+        self.resolved_hostnames.update(resolved_map)
+
+        # If hostnames don't resolve, we still need to add them without IP
+        # because hosts resolution could be broken..
+        for host in hostnames:
+            if host not in self.resolved_hostnames:
+                log.debug("Adding hostname: %s without IP. Check DNS!", host)
+                self.resolved_hostnames.update(host = None)
+
+    def add_hostname(self, name, ip=None):
+        # Add single hostname-ip pair. Ensure valid format
+        if self.locked:
+            log.warn("Denied: add hostname:ip pair to locked OsiHostResolver")
+            return
+        if not isip(ip):
+            log.ERROR("Denied: Can't add invalid IP: %s", ip)
+            return
+
+        valid_name = extract_valid_hostname(name)
+        if not valid_name:
+            log.ERROR("Denied: Can't add invalid Hostname: %s", name)
+
+        self.resolved_hostnames[valid_name] = ip
+
+    def getIpFromName(self, hostname):
+        ip = self.resolved_hostnames.get(hostname)
+        if not ip:
+            log.debug("resolved_hostnames: Missing IP for host %s", hostname)
+        return ip
+
+    def hasIpFromName(self, name):
+        if name in self.resolved_hostnames:
+            return True
+
+    def get_ip_addresses(self):
+        return set(self.resolved_hostnames.values())
+
+    def get_resolved(self):
+        return self.resolved_hostnames
+
+
+class OsiDnsHost(object):
+    '''
+    OsiDnsHost represents resolvable hosts in the OSI cluster.
+    It requires a valid OsiHostResolver instance object in order to get
+    pre-resolved IP addresses. When fully populated, objects have:
+    @locked: lock host from updates
+    @ip: The IP address
+    @hostname: The optional hostname
+    @canonical_hostname: The hostname that represents this host, deterministic
+    '''
+
+    def __new__(cls, ip=None, hostname=None, canonical=None):
+        if not (ip or hostname):
+            log.error("Missing IP and Hostname for OsiDnsHost creation!")
+            return
+        else:
+            return object.__new__(cls)
+
+    def __init__(self, ip=None, hostname=None, canonical=None):
+
+        if not (ip or hostname):
+            log.error("Missing IP or Hostname for OsiDnsHost creation!")
+            # raise Exception("Missing IP or Hostname for OsiDnsHost creation!")
+
+        self.locked = False
+
+        if not ip:
+            log.debug("Missing IP for OsiDnsHost creation. Check DNS")
+            self.ip = None
+        elif not isip(ip):
+            log.warn("Bad IP in OsiDnsHost creation!")
+            self.ip = None
+        else:
+            self.ip = ip
+
+        self.hostnames = set()
+        if hostname:
+            self.add_hostname(hostname)
+
+        self.canonical_hostname = None
+        if canonical:
+            self.canonical_hostname = canonical
+
+    def __eq__(self, other):
+        # Allows set(OsiDnsHost) to determine equailty based on contents
+        if isinstance(other, OsiDnsHost):
+            return self.ip == other.ip and self.hostnames == other.hostnames
+        return False
+
+    def __ne__(self, other):
+        # Allows set(OsiDnsHost) to determine equailty based on contents
+        return (not self.__eq__(other))
+
+    def __repr__(self):
+        # Allows set(OsiDnsHost) to determine equailty based on contents
+        return 'H({s.ip!r}, {s.hostnames!r})'.format(s=self)
+
+    def __hash__(self):
+        # Allows set(OsiDnsHost) to determine equailty based on contents
+        return hash(repr(self))
+
+    def lock(self):
+        self.locked = True
+
+    def unlock(self):
+        self.locked = False
+
+    def get_id(self):
+        # NOTE: process information in self.hostnames in order to synthesize a
+        # unique hostname. Typically we will take the most fully qualified
+        # domain name that is found.
+        if not self.hostnames:
+            log.warn("get_id: No hostnames available")
+            return
+
+        return prepId('host-{}'.format(self.canonical_hostname))
+
+    def get_ip(self):
+        return self.ip
+
+    def get_canonical_hostname(self):
+        # NOTE: process information in self.hostnames in order to synthesize a
+        # unique hostname. Take the first host in alphabetical order
+        # Use cached value if available
+        if not self.hostnames:
+            log.warn("get_canonical: No hostnames for OsiDnsHost %s", self.ip)
+            return
+
+        if self.canonical_hostname:
+            return self.canonical_hostname
+
+        domain = get_dominant_domain(self.hostnames)
+        if not domain:
+            log.debug("Missing domain for %s: Returning first host", self.ip)
+            hosts = sorted(self.hostnames)
+            canonical = next((x for x in hosts if not isip(x)), hosts[0])
+            return canonical
+
+        host_candidates = [h for h in self.hostnames if domain in h]
+        return sorted(host_candidates)[0]
+
+    def set_canonical_hostname(self):
+        # NOTE: process information in self.hostnames in order to synthesize a
+        # unique hostname. Typically we will take the most fully qualified
+        # domain name that is found.
+        if self.locked:
+            log.warn("Won't update canonical on locked OsiDnsHost %s", self.ip)
+            return
+
+        self.canonical_hostname = None
+        self.canonical_hostname = self.get_canonical_hostname()
+
+    def add_hostname(self, hostname, ip=None):
+        # NOTE: We don't update self.canonica_hostname here. Must do manually.
+        if self.locked:
+            log.warn("Won't add %s to locked OsiDnsHost %s", hostname, self.ip)
+            return
+
+        # If hostname is in hostnames, pass, else check IP: add it
+        hostname = extract_valid_hostname(hostname)
+        if hostname in self.hostnames:
+            log.debug("add_hostname: host alreay exists!")
+            return
+
+        if not self.ip and ip:
+            log.debug("adding hostname %s, ip: %s", hostname, self.ip)
+            self.ip = ip
+            self.hostnames.add(hostname)
+            return
+
+        if ip and self.ip:
+            if self.ip == ip:
+                log.debug("adding hostname, ip: %s -> %s", hostname, self.ip)
+                self.hostnames.add(hostname)
+            else:
+                log.debug("add_hostname: IPs don't match! %s, %s for %s",
+                        self.ip, ip, hostname)
+            return
+
+        self.hostnames.add(hostname)
+
+    def update_hostnames(self, hostnames):
+        # Add hostnames in batch.
+        # We blindly assume that these hostnames are valid for this host.
+        if self.locked:
+            log.warn("Won't add hosts to locked OsiDnsHost %s", self.ip)
+            return
+
+        if isinstance(hostnames, (list, set)):
+            for host in hostnames:
+                self.add_hostname(extract_valid_hostname(host))
+
+    def has_ip(self, ip):
+        if ip == self.ip:
+            return True
+
+    def has_hostname(self, hostname):
+        if hostname.lower() in self.hostnames:
+            return True
+
+    def is_equal(self, dnsHost):
+        # This is comparison of two objects.
+        # NOTE: Comparison of hostnames is suspect: Why can't they differ?
+        if dnsHost.get_ip() in self.ip and dnsHost.hostnames == self.hostnames:
+            return True
+
+    def valid_hostname_ip(self):
+        # Check if hostname corresponds to a valid IP via socket call
+        # NOTE: socket calls are blocking; this can be slow!
+        if socket.gethostbyname(self.get_canonical_hostname()) == self.ip:
+            return True
+
+    def merge(self, osiHost):
+        # Merge 2 host objects that have same IP's
+        self.locked = False
+        if self.ip == osiHost.ip:
+            self.hostnames = osiHost.hostnames.union(self.hostnames)
+
+    def is_subset(self, osiHost):
+        # Merge 2 host objects that have like IP's
+        if self.ip == osiHost.ip and self.hostnames < osiHost.hostnames:
+            return True
+
+
+class OsiHostGroup(object):
+    '''
+    Class that contains a collection of OsiDnsHost objects.
+    '''
+
+    def __init__(self, hostResolver=None):
+        if not isinstance(hostResolver, OsiHostResolver):
+            raise OsiDnsError("Invalid OsiHostResolver instance for OsiHostGroup")
+        self.hostResolver = hostResolver
+        self.hosts = set()
+
+    def update_Resolver(self, hostResolver):
+        if not isinstance(hostResolver, OsiHostResolver):
+            raise OsiDnsError("Invalid OsiHostResolver instance for OsiHostGroup")
+        else:
+            self.hostResolver = hostResolver
+
+    def get_host_by_name_or_ip(self, thing):
+        # Determine if thing is valid ip
+        thing = extract_valid_hostname(thing)
+        if isip(thing):
+            return self.get_host_by_ip(thing)
+
+        # Find host by name only
+        host = self.get_host_by_name(thing)
+        if host:
+            return host
+
+        # Be careful: Need to convert name to ip and check again
+        ip = self.hostResolver.getIpFromName(thing)
+        if ip:
+            return self.get_host_by_ip(ip)
+
+    def get_host_by_ip(self, ip):
+        # Determine if ip is valid
+        if not isip(ip):
+            log.debug("Invalid IP: %s", ip)
+            return
+
+        # Find the proper host in hosts set given host_or_ip
+        for host in self.hosts:
+            if ip == host.get_ip():
+                return host
+
+    def get_host_by_name(self, name):
+        # Determine if name is valid
+        name = extract_valid_hostname(name)
+
+        # Find the proper host in hosts set given host_or_ip
+        for host in self.hosts:
+            if name in host.hostnames:
+                return host
+
+    def has_equivalent(self, osiHost):
+        # Boolean: Test if self has equiv osiHost buy value
+        if not isinstance(osiHost, OsiDnsHost):
+            log.warn("host is non-OsiDnsHost. Unable to compare.")
+            return
+
+        # Find the proper host in hosts set given host_or_ip
+        for host in self.hosts:
+            if osiHost.ip == host.ip and osiHost.hostnames == host.hostnames:
+                return True
+        return False
+
+    def is_subset_host(self, osiHost):
+        # If osiHost is subset of some host in set, return True
+        if not isinstance(osiHost, OsiDnsHost):
+            log.warn("host is non-OsiDnsHost. Unable to compare.")
+            return
+
+        for host in self.hosts:
+            if osiHost.is_subset(host):
+                return True
+
+        return False
+
+    def get_subset_host(self, osiHost):
+        # Return host that is subset of this host
+        if not isinstance(osiHost, OsiDnsHost):
+            log.warn("host is non-OsiDnsHost. Unable to compare.")
+            return
+
+        for host in self.hosts:
+            if osiHost.is_subset(host):
+                return host
+
+    def has_hostname(self, hostname):
+        # Boolean: Test if osiHost IP is in hosts set
+        for host in self.hosts:
+            if hostname in host.hostnames:
+                return True
+        return False
+
+    def has_ip(self, ip):
+        # Boolean: Test if osiHost IP is in hosts set
+        for host in self.hosts:
+            if host.ip == ip:
+                return True
+
+        return False
+
+    def add_host(self, osiHost):
+        # Add OsiDnsHost instance to set, but only if unique. Otherwise merge.
+        if not isinstance(osiHost, OsiDnsHost):
+            log.warn("Can't add an non OsiDnsHost object")
+            return
+
+        if self.has_equivalent(osiHost) or self.is_subset_host(osiHost):
+            log.debug("osiHost %s is Subset", osiHost)
+            return
+
+        host_subset = self.get_subset_host(osiHost)
+        if host_subset:
+            log.debug("Found subset: %s of %s", host_subset, osiHost)
+            host_subset.merge(osiHost)
+        else:
+            self.hosts.add(osiHost)
+
+    def remove_host(self, osiHost):
+        # Delete OsiDnsHost object
+        if not isinstance(osiHost, OsiDnsHost):
+            log.debug("Can't remove an non OsiDnsHost object")
+            return
+
+        self.hosts.remove(osiHost)
+
+    def update_canonical_hostnames(self):
+        # Update canaonical_hostname for all hosts
+        for host in self.hosts:
+            host.set_canonical_hostname()
+
+    def add_hostname(self, name):
+        # Add hostname if it is not already in set.
+        name = extract_valid_hostname(name)
+        if not name:
+            log.warn("Missing name for add_hostname!")
+            return
+
+        # If host already in the set, find it and return host
+        found = self.get_host_by_name_or_ip(name)
+        if found:
+            found.add_hostname(name)
+            return
+
+        # If new host is an IP, add it as such
+        if isip(name):
+            self.add_host(OsiDnsHost(ip=name))
+            return
+
+        # Host is new hostname, so add it as such. IP can be None:
+        ip = self.hostResolver.getIpFromName(name)
+        if ip:
+            osiHost = OsiDnsHost(ip)
+            osiHost.add_hostname(name)
+        else:
+            log.warn("Adding host %s to a baren (missing ip) host!", name)
+            osiHost = OsiDnsHost(hostname=name)
+
+        self.add_host(osiHost)
+
+    def add_hostnames(self, hostnames):
+        # Add an OsiDnsHost for each corresponding name in hostnames
+        for host in hostnames:
+            self.add_hostname(host)
+# ==============================================================================
+# ==============================================================================
+# ==============================================================================
+
+
+@inlineCallbacks
+def main():
+
+    hostnames = set()
+    hostnames.add('io.com')
+    hostnames.add('www.io.com')
+    hostnames.add('216.58.194.110')
+    hostnames.add('amb5v.x.incapdns.net')
+
+    other_dns = {'agate.google.com': '1.2.3.4',
+                   'acacia.google.com': '1.2.3.4',
+                   'aol.box': '3.3.3.3',
+                   'www.io.com.localhost': '192.230.66.239',
+                   'xyz.googl3.com': '1.2.3.4',
+                   'peter.google.com': '1.2.3.4',
+                   'best.example.com': '8.2.3.4',
+                   'average.example.com': '8.2.3.4',
+                   'worst.example.com': '8.2.3.4',
+                   }
+
+    others = set(other_dns.keys())
+    hostnames.update(others)
+
+    print hostnames
+    print "Entry main()"
+
+    try:
+
+        # This dns object is the authoritative source of DNS information
+        dns1 = OsiHostResolver()
+
+        dns2 = OsiHostResolver()
+
+        yield dns1.bulk_update_names(hostnames)
+        yield dns2.bulk_update_names(hostnames)
+
+        # Tests of various things
+        dns1.lock()
+        dns1.add_hostnames(other_dns)
+        dns1.unlock()
+        dns1.add_hostnames(other_dns)
+        print dns1
+
+        # Tests of various things
+        dns2.add_hostnames(other_dns)
+        dns2.unlock()
+        dns2.add_hostnames(other_dns)
+        dns2.add_hostname('xio.com', '10.10.10.2')
+
+    except Exception as e:
+
+        print "General exception: {}".format(e)
+
+    else:
+        # print dns.resolved_hostnames
+        print dns1.getIpFromName('google.com')
+
+    try:
+        # host1 = OsiDnsHost(dns, ip='192.230.66.239')
+        # host1 = OsiDnsHost(dns, ip='', hostnames=hostnames)
+
+        host0 = OsiDnsHost()
+        try:
+            host0.add_hostname(ip=None, hostname='ioc.com')
+        except Exception:
+            log.warn("********* host0 is bad ********* ")
+
+        host1 = OsiDnsHost(ip='192.230.66.239')
+        host2 = OsiDnsHost(ip='1.2.3.4')
+        host3 = OsiDnsHost(ip='1.2.3.4')
+        host4 = OsiDnsHost(ip='1.2.3.4')
+
+    except OsiDnsError as ex:
+        log.error(ex)
+
+    else:
+
+        for host, ip in dns1.resolved_hostnames.items():
+            host1.add_hostname(host, ip)
+
+        print "host1.get_ip() = {}".format(host1.get_ip())
+        print "host1 = {}".format(host1.hostnames)
+        print "host1 ip {0}, hosts {1}".format(host1.get_ip(), host1.hostnames)
+        print "Host1 ID = ", host1.get_id()
+
+        # Test: add hostname with .localhost extension
+        host2.add_hostname('www.io.com.localhost')
+
+        # Test: add hostname without host part, missing IP.
+        host2.add_hostname('google.com')
+
+        # Test: add hostname with wrong dns, missing IP.
+        host2.add_hostname('www.google.com')
+
+        # Test: add hostname with correct dns
+        # Test: lock
+        host2.lock()
+        host2.add_hostname('agate.google.com')
+        # Test: unlock
+        host2.unlock()
+        # Test: add another hostname with correct dns
+        host2.add_hostname('Peter.google.com')
+        host2.add_hostname('agate.google.com')
+        # Test Add unknown host
+        host2.add_hostname('abba.google.com')
+        # Test Add known host
+        host2.add_hostname('acacia.google.com')
+
+        print "Host2 ID = ", host2.get_id()
+        print host2.get_ip()
+        print "Host2 hostnames = ", host2.hostnames
+        print "Canonical hostname = ", host2.get_canonical_hostname()
+
+        # Host 3 to test equality and merging and set(OsiDnsHosts)
+        host3.add_hostname('agate.google.com')
+        host4.add_hostname('agate.google.com')
+        host4.add_hostname('acacia.google.com')
+        print "host3 == host4: ", host3 == host4
+        print "host3.__hash__ : ", host3.__hash__()
+        print "host4.__hash__ : ", host4.__hash__()
+
+        # Test: Remove host from s
+
+        hostgroup = OsiHostGroup(hostResolver=dns1)
+        ipadds = dns1.get_ip_addresses()
+        for ip in ipadds:
+            host = OsiDnsHost(ip=ip)
+            hostgroup.add_host(host)
+
+        for host in hostgroup.hostResolver.resolved_hostnames:
+            hostgroup.add_hostname(host)
+
+        print "host4 in hostgroup", host4 in hostgroup.hosts
+
+        # Test if host4 in hostgroup
+        print "host4 in hostgroup", host4 in hostgroup.hosts
+        print "hostgroup has host1:", hostgroup.has_equivalent(host1)
+        print "hostgroup has host2:", hostgroup.has_equivalent(host2)
+        print "hostgroup count:", len(hostgroup.hosts)
+
+        host3.merge(host4)
+
+        print "host3 == host4", host3 == host4
+
+        for host in hostgroup.hosts:
+            print "---------------------"
+            print "IP = ", host.ip
+            print "Hostnames = ", host.hostnames
+            print "Canonical Hostname = ", host.get_canonical_hostname()
+
+    if reactor.running:
+        reactor.stop()
+
+if __name__ == '__main__':
+    main()
+    reactor.run()
+
+#===============================================================================

--- a/ZenPacks/zenoss/OpenStackInfrastructure/modeler/plugins/zenoss/OpenStackInfrastructure.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/modeler/plugins/zenoss/OpenStackInfrastructure.py
@@ -21,13 +21,11 @@ import os
 import re
 import itertools
 from urlparse import urlparse
-import socket
 from collections import defaultdict
 
 from twisted.internet.defer import inlineCallbacks, returnValue
 from twisted.internet.error import ConnectError, TimeoutError
 
-from Products.ZenUtils.IpUtil import isip, asyncIpLookup
 from Products.DataCollector.plugins.CollectorPlugin import PythonPlugin
 from Products.DataCollector.plugins.DataMaps import ObjectMap, RelationshipMap
 from Products.ZenUtils.Utils import prepId
@@ -40,12 +38,14 @@ from ZenPacks.zenoss.OpenStackInfrastructure.utils import (
     get_port_instance,
     getNetSubnetsGws_from_GwInfo,
     get_port_fixedips,
-    sleep,
     isValidHostname,
-    sanitize_host_or_ip,
 )
-
 add_local_lib_path()
+
+from ZenPacks.zenoss.OpenStackInfrastructure.lib.OsiDnsHost import (
+        OsiHostResolver,
+        OsiHostGroup,
+        )
 
 from apiclients.txapiclient import APIClient, APIClientError, NotFoundError
 
@@ -226,7 +226,7 @@ class OpenStackInfrastructure(PythonPlugin):
         result = yield client.neutron_floatingips()
         results['floatingips'] = result['floatingips']
 
-        # Do some DNS lookups as well.
+        # Compile all hosts into a set
         hostnames = set([x['host'] for x in results['services']])
         hostnames.update([x['host'] for x in results['agents']])
         hostnames.update(device.zOpenStackExtraHosts)
@@ -236,33 +236,23 @@ class OpenStackInfrastructure(PythonPlugin):
         except Exception, e:
             log.warning("Unable to determine nova URL for nova-api component discovery: %s" % e)
 
-        # not being able to resolve hostname could, in some cases,
+        # ---------------------------------------------------------------------
+        # DNS Resolution and Hostgroups
+        # ---------------------------------------------------------------------
+        # Not being able to resolve hostname could, in some cases,
         # result in nova-api and/or cinder-api components not being modeled
-        # make sure DNS can resolve controller hostname
+        # make sure DNS can resolve controller hostnames
 
-        results['resolved_hostnames'] = {}
-        for hostname in sorted(hostnames):
-            if isip(hostname):
-                results['resolved_hostnames'][hostname] = hostname
-                continue
+        # Create the hostResolver object for DNS resolution
+        hostResolver = OsiHostResolver()
+        yield hostResolver.bulk_update_names(hostnames)
 
-            for i in range(1, 4):
-                try:
-                    host_ip = yield asyncIpLookup(hostname)
-                    results['resolved_hostnames'][hostname] = host_ip
-                    break
-                except socket.gaierror, e:
-                    if e.errno == -3:
-                        # temporary dns issue- try again.
-                        log.error("resolve %s: (attempt %d/3): %s" % (hostname, i, e))
-                        yield sleep(2)
-                        continue
-                    else:
-                        log.error("resolve %s: %s" % (hostname, e))
-                        break
-                except Exception, e:
-                    log.error("resolve %s: %s" % (hostname, e))
-                    break
+        # Create hostGroup with hostResolver instance
+        hostgroup = OsiHostGroup(hostResolver=hostResolver)
+        hostgroup.add_hostnames(hostnames)
+        hostgroup.update_canonical_hostnames()
+        results['hostgroup'] = hostgroup
+        # ---------------------------------------------------------------------
 
         # Cinder
         result = yield client.cinder_volumes()
@@ -299,6 +289,7 @@ class OpenStackInfrastructure(PythonPlugin):
         returnValue(results)
 
     def process(self, device, results, unused):
+
         tenants = []
         quota_tenants = []                   # for use by quota later
         for tenant in results['tenants']:
@@ -459,22 +450,32 @@ class OpenStackInfrastructure(PythonPlugin):
         services = []
         zones = {}
         hostmap = {}
+        hostgroup = results['hostgroup']
 
         # Find all hosts which have a nova service on them.
         for service in results['services']:
             if not service.get('id', None):
                 continue
 
+            # Use only canonical hosts as discovered in collect
+            osiHost = hostgroup.get_host_by_name_or_ip(service.get('host'))
+
+            if not osiHost:
+                log.warn("No host %s for service %s!", service.get('host'), service.get('id'))
+                continue
+
             title = '{0}@{1} ({2})'.format(service.get('binary', ''),
-                                           service.get('host', ''),
+                                           osiHost.get_canonical_hostname(),
                                            service.get('zone', ''))
             service_id = prepId('service-{0}-{1}-{2}'.format(
-                service.get('binary', ''), service.get('host', ''), service.get('zone', '')))
-            host_id = prepId("host-{0}".format(service.get('host', '')))
+                service.get('binary', ''),
+                osiHost.get_canonical_hostname(),
+                service.get('zone', '')))
+            host_id = osiHost.get_id()
             zone_id = prepId("zone-{0}".format(service.get('zone', '')))
 
             hostmap[host_id] = {
-                'hostname': service.get('host', ''),
+                'hostname': osiHost.get_canonical_hostname(),
                 'org_id': zone_id
             }
 
@@ -516,16 +517,16 @@ class OpenStackInfrastructure(PythonPlugin):
             if not agent.get('id', None):
                 continue
 
-            sanitized_hostname = sanitize_host_or_ip(agent['host'])
-            if not sanitized_hostname:
-                log.debug("Skipping empty hostname %s !", agent['host'])
+            raw_hostname = agent.get('host')
+            osiHost = hostgroup.get_host_by_name_or_ip(raw_hostname)
+            if not osiHost:
+                log.warn("Host %s not found for agent %s!",
+                                            raw_hostname, agent.get('id'))
                 continue
-            if sanitized_hostname != agent['host']:
-                log.debug("Sanitized hostname %s", agent['host'])
 
-            host_id = prepId("host-{0}".format(sanitized_hostname))
+            host_id = osiHost.get_id()
             hostmap[host_id] = {
-                'hostname': sanitized_hostname,
+                'hostname': osiHost.get_canonical_hostname(),
                 'org_id': region_id
             }
 
@@ -534,21 +535,27 @@ class OpenStackInfrastructure(PythonPlugin):
         for service in results['cinder_services']:
             # well, guest what? volume services do not have 'id' key !
 
-            host_id_end = service.get('host', '').find('@')
-            if host_id_end > -1:
-                host_id = prepId("host-{0}".format(service.get('host', '')[:host_id_end]))
-            else:
-                host_id = prepId("host-{0}".format(service.get('host', '')))
+            raw_hostname = service.get('host', '')
+            osiHost = hostgroup.get_host_by_name_or_ip(raw_hostname)
+
+            if not osiHost:
+                log.warn("Host %s not found for cinder_service %s!",
+                                    raw_hostname, service.get('binary'))
+                continue
+
+            host_id = osiHost.get_id()
+            canonical_hostname = osiHost.get_canonical_hostname()
+
             zone_id = prepId("zone-{0}".format(service.get('zone', '')))
             title = '{0}@{1} ({2})'.format(service.get('binary', ''),
-                                           service.get('host', ''),
+                                           raw_hostname,
                                            service.get('zone', ''))
             service_id = prepId('service-{0}-{1}-{2}'.format(
-                service.get('binary', ''), service.get('host', ''), service.get('zone', '')))
+                service.get('binary', ''), canonical_hostname, service.get('zone', '')))
 
             if host_id not in hostmap:
                 hostmap[host_id] = {
-                    'hostname': service.get('host', ''),
+                    'hostname': canonical_hostname,
                     'org_id': zone_id
                 }
             services.append(ObjectMap(
@@ -579,12 +586,20 @@ class OpenStackInfrastructure(PythonPlugin):
                 log.info("  Adding zOpenStackExtraHosts=%s" % device.zOpenStackExtraHosts)
 
         for hostname in device.zOpenStackNovaApiHosts + device.zOpenStackExtraHosts:
-            host_id = prepId("host-{0}".format(hostname))
+            osiHost = hostgroup.get_host_by_name_or_ip(hostname)
+
+            if not osiHost:
+                log.warn("Skipping missing AdditionalHost  %s !", hostname)
+                continue
+
+            canonical_hostname = osiHost.get_canonical_hostname()
+            host_id = osiHost.get_id()
             hostmap[host_id] = {
-                'hostname': hostname,
+                'hostname': canonical_hostname,
                 'org_id': region_id
             }
 
+        # Here: hostmap should be free of duplicates and bogons
         hosts = []
         for host_id in hostmap:
             data = hostmap[host_id]
@@ -595,7 +610,7 @@ class OpenStackInfrastructure(PythonPlugin):
                 # and the hostname in hostmap becomes:
                 # 'host-overcloud-controller-1.localdomain:4947de00-0c13-5ee7-902e-fc270d3993b9'
                 # this caused problem when setting orgComponent for agent
-                log.warn("  Invalid hostname found: %s" % data.get('hostname', host_id))
+                log.warn("Invalid hostname found: %s" % data.get('hostname', host_id))
                 continue
 
             hosts.append(ObjectMap(
@@ -701,6 +716,7 @@ class OpenStackInfrastructure(PythonPlugin):
         # Place it on the user-specified hosts, or also find it if it's
         # in the nova-service list (which we ignored earlier). It should not
         # be, under icehouse, at least, but just in case this changes..)
+
         nova_api_hosts = set(device.zOpenStackNovaApiHosts)
         cinder_api_hosts = []
         for service in results['services']:
@@ -716,9 +732,21 @@ class OpenStackInfrastructure(PythonPlugin):
         # api hosts.
         try:
             apiHostname = urlparse(results['nova_url']).hostname
-            apiIp = results['resolved_hostnames'].get(apiHostname, apiHostname)
+            osiHost = hostgroup.get_host_by_name_or_ip(apiHostname)
+
+            if not osiHost:
+                log.warn("Missing or invalid apiHostname %s !", apiHostname)
+                raise Exception
+
+            canonical_hostname = osiHost.get_canonical_hostname()
+            apiIp = osiHost.get_ip()
+
+            if not apiIp:
+                log.warn("Using hostname for Missing IP for apiHostname %s!", apiHostname)
+                apiIp = apiHostname
+
             for host in hosts:
-                if host.hostname == apiHostname:
+                if host.hostname == canonical_hostname:
                     nova_api_hosts.add(host.hostname)
                     cinder_api_hosts.append(host.hostname)
                 else:
@@ -769,18 +797,19 @@ class OpenStackInfrastructure(PythonPlugin):
         # agent
         agents = []
         for agent in results['agents']:
-            if not agent.get('id', None):
+            if not agent.get('id'):
                 continue
-
-            sanitized_hostname = sanitize_host_or_ip(agent['host'])
-            if not sanitized_hostname:
-                log.debug("Skipping empty hostname %s !", agent['host'])
-                continue
-            if sanitized_hostname != agent['host']:
-                log.debug("Sanitized hostname %s", agent['host'])
 
             # Get agent's host
-            agent_host = prepId('host-{0}'.format(sanitized_hostname))
+            raw_host = agent['host']
+            osiHost = hostgroup.get_host_by_name_or_ip(raw_hostname)
+
+            if not osiHost:
+                log.warn("Skipped missing Host %s for Agent %s!",
+                                raw_host, agent.get('id'))
+                continue
+
+            agent_host = osiHost.get_id()
 
             # ------------------------------------------------------------------
             # AgentSubnets Section
@@ -1017,6 +1046,7 @@ class OpenStackInfrastructure(PythonPlugin):
             voltypeid = [vtype.id for vtype in voltypes
                          if volume.get('volume_type', '') == vtype.title]
 
+            # >>>> canonicalize hosts here
             volume_dict = dict(
                 id=prepId('volume-{0}'.format(volume['id'])),
                 title=volume.get('name', ''),

--- a/ZenPacks/zenoss/OpenStackInfrastructure/modeler/plugins/zenoss/OpenStackInfrastructure.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/modeler/plugins/zenoss/OpenStackInfrastructure.py
@@ -42,9 +42,9 @@ from ZenPacks.zenoss.OpenStackInfrastructure.utils import (
 )
 add_local_lib_path()
 
-from ZenPacks.zenoss.OpenStackInfrastructure.lib.OsiDnsHost import (
-        OsiHostResolver,
-        OsiHostGroup,
+from ZenPacks.zenoss.OpenStackInfrastructure.lib.HostMap import (
+        HostResolver,
+        HostGroup,
         )
 
 from apiclients.txapiclient import APIClient, APIClientError, NotFoundError
@@ -244,11 +244,11 @@ class OpenStackInfrastructure(PythonPlugin):
         # make sure DNS can resolve controller hostnames
 
         # Create the hostResolver object for DNS resolution
-        hostResolver = OsiHostResolver()
+        hostResolver = HostResolver()
         yield hostResolver.bulk_update_names(hostnames)
 
         # Create hostGroup with hostResolver instance
-        hostgroup = OsiHostGroup(hostResolver=hostResolver)
+        hostgroup = HostGroup(hostResolver=hostResolver)
         hostgroup.add_hostnames(hostnames)
         hostgroup.update_canonical_hostnames()
         results['hostgroup'] = hostgroup
@@ -906,12 +906,12 @@ class OpenStackInfrastructure(PythonPlugin):
         for port in results['ports']:
             if not port.get('id', None):
                 continue
-            port_dict= dict()
+            port_dict = dict()
             # Fetch the subnets for later use
             raw_subnets = get_subnets_from_fixedips(port.get('fixed_ips', []))
             port_subnets = [prepId('subnet-{}'.format(x)) for x in raw_subnets]
             if port_subnets:
-                port_dict['set_subnets']= port_subnets
+                port_dict['set_subnets'] = port_subnets
             # Prepare the device_subnet_list data for later use.
             port_router_id = port.get('device_id')
             if port_router_id:

--- a/ZenPacks/zenoss/OpenStackInfrastructure/tests/test_model.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/tests/test_model.py
@@ -26,9 +26,9 @@ from Products.ZenTestCase.BaseTestCase import BaseTestCase
 from ZenPacks.zenoss.OpenStackInfrastructure.modeler.plugins.zenoss.OpenStackInfrastructure \
     import OpenStackInfrastructure as OpenStackInfrastructureModeler
 
-from ZenPacks.zenoss.OpenStackInfrastructure.lib.OsiDnsHost import (
-        OsiHostResolver,
-        OsiHostGroup,
+from ZenPacks.zenoss.OpenStackInfrastructure.lib.HostMap import (
+        HostResolver,
+        HostGroup,
         )
 
 CLOUDSTACK_ICON = '/++resource++cloudstack/img/cloudstack.png'
@@ -78,9 +78,9 @@ class TestModel(BaseTestCase):
         # We need to create and add the hostgroup data structure to results
         # ---------------------------------------------------------------------
         resolved_hostnames = results.get('resolved_hostnames')
-        hostResolver = OsiHostResolver()
+        hostResolver = HostResolver()
         hostResolver.resolved_hostnames = resolved_hostnames
-        hostgroup = OsiHostGroup(hostResolver=hostResolver)
+        hostgroup = HostGroup(hostResolver=hostResolver)
         hostnames = resolved_hostnames.keys()
         hostgroup.add_hostnames(hostnames)
         hostgroup.update_canonical_hostnames()

--- a/ZenPacks/zenoss/OpenStackInfrastructure/tests/test_model.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/tests/test_model.py
@@ -26,6 +26,11 @@ from Products.ZenTestCase.BaseTestCase import BaseTestCase
 from ZenPacks.zenoss.OpenStackInfrastructure.modeler.plugins.zenoss.OpenStackInfrastructure \
     import OpenStackInfrastructure as OpenStackInfrastructureModeler
 
+from ZenPacks.zenoss.OpenStackInfrastructure.lib.OsiDnsHost import (
+        OsiHostResolver,
+        OsiHostGroup,
+        )
+
 CLOUDSTACK_ICON = '/++resource++cloudstack/img/cloudstack.png'
 
 
@@ -68,6 +73,19 @@ class TestModel(BaseTestCase):
                                'data',
                                'modeldata.json')) as json_file:
             results = json.load(json_file)
+
+        # ---------------------------------------------------------------------
+        # We need to create and add the hostgroup data structure to results
+        # ---------------------------------------------------------------------
+        resolved_hostnames = results.get('resolved_hostnames')
+        hostResolver = OsiHostResolver()
+        hostResolver.resolved_hostnames = resolved_hostnames
+        hostgroup = OsiHostGroup(hostResolver=hostResolver)
+        hostnames = resolved_hostnames.keys()
+        hostgroup.add_hostnames(hostnames)
+        hostgroup.update_canonical_hostnames()
+        results['hostgroup'] = hostgroup
+        # ---------------------------------------------------------------------
 
         for data_map in modeler.process(self.d, results, log):
             self.applyDataMap(self.d, data_map)


### PR DESCRIPTION
Fixes ZEN-22373.

* Create OsiDnsHost object that carries all equivalent hosts
* OsiHostGroup conains all OsiDnsHosts and Resolver data
* Consolidate host operations in OsiHostGroup and OsiDnsHosts
* Combine host validation and sanitizing
* Refactor Unit Tests for new modeler structure