### PR TITLE
Clean up code after nfvi merge

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -205,6 +205,36 @@ Routers
 Zenoss, and all events processed through Ceilometer are exposed via the
 Zenoss Event Console.
 
+==Host Based Installation vs Container Based Installation==
+
+This zenpack supports both host based installation and container based
+installation.
+
+===Host Based Installation===
+
+With host based installation, the OpenStack binaries are directly installed on
+the host. For instance,  the binary nova-api would be installed directly in the
+controller host's /usr/bin directory. In this case, leave the zProperties
+zOpenStackRunNovaManageInContainer, zOpenStackRunVirshQemuInContainer, and
+zOpenStackRunNeutronCommonInContainer unset in zenpack.yaml:
+<syntaxhighlight lang="bash">
+      zOpenStackRunNovaManageInContainer:
+      zOpenStackRunVirshQemuInContainer:
+      zOpenStackRunNeutronCommonInContainer:
+</syntaxhighlight>
+
+===Container Based Installation===
+
+With container based installation, each OpenStack binary runs inside its own
+container. In this case, set the zProperties zOpenStackRunNovaManageInContainer,
+zOpenStackRunVirshQemuInContainer, and zOpenStackRunNeutronCommonInContainer in
+zenpack.yaml as:
+<syntaxhighlight lang="bash">
+      zOpenStackRunNovaManageInContainer: novaconduct
+      zOpenStackRunVirshQemuInContainer: novacompute
+      zOpenStackRunNeutronCommonInContainer: neutron_server
+</syntaxhighlight>
+
 ==Ceilometer Enablement==
 
 Although you may add an OpenStack device to Zenoss, as shown above, event and

--- a/ZenPacks/zenoss/OpenStackInfrastructure/modeler/plugins/zenoss/cmd/linux/openstack/inifiles.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/modeler/plugins/zenoss/cmd/linux/openstack/inifiles.py
@@ -118,9 +118,14 @@ class inifiles(PythonPlugin):
         filepath = os.path.join(device.zOpenStackNeutronConfigDir, filename)
         log.info("Retrieving %s", filepath)
 
-        cmd = container_cmd_wrapper(
-            device.zOpenStackRunNeutronCommonInContainer, "cat %s" % filepath
-        )
+        # host based installation
+        cmd = "cat %s" % filepath
+        if device.zOpenStackRunNeutronCommonInContainer:
+            # container based installation
+            cmd = container_cmd_wrapper(
+                device.zOpenStackRunNeutronCommonInContainer, "cat %s" % \
+                                                              filepath
+            )
         d = yield self.client.run(cmd, timeout=self.timeout)
 
         if d.exitCode != 0 or d.stderr:
@@ -167,10 +172,14 @@ class inifiles(PythonPlugin):
 
         try:
             # Check if neutron-server runs on this machine
-            cmd = container_cmd_wrapper(
-                device.zOpenStackRunNeutronCommonInContainer,
-                "pgrep neutron-server"
-            )
+            # host based installation
+            cmd = "pgrep neutron-server"
+            if device.zOpenStackRunNeutronCommonInContainer:
+                # container based installation
+                cmd = container_cmd_wrapper(
+                    device.zOpenStackRunNeutronCommonInContainer,
+                    "pgrep neutron-server"
+                )
             d = yield self.client.run(cmd, timeout=self.timeout)
 
             if d.exitCode != 0:

--- a/ZenPacks/zenoss/OpenStackInfrastructure/modeler/plugins/zenoss/cmd/linux/openstack/libvirt.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/modeler/plugins/zenoss/cmd/linux/openstack/libvirt.py
@@ -69,10 +69,15 @@ class libvirt(PythonPlugin):
 
         try:
             for instanceId, instanceUUID in device.openstack_instanceList:
-                cmd = container_cmd_wrapper(
-                    device.zOpenStackRunVirshQemuInContainer,
-                    "virsh --readonly -c 'qemu:///system' dumpxml '%s'" %
-                    instanceUUID)
+                # host based installation
+                cmd = "virsh --readonly -c 'qemu:///system' dumpxml '%s'" % \
+                      instanceUUID
+                if device.zOpenStackRunNeutronCommonInContainer:
+                    # container based installation
+                    cmd = container_cmd_wrapper(
+                        device.zOpenStackRunVirshQemuInContainer,
+                        "virsh --readonly -c 'qemu:///system' dumpxml '%s'" % \
+                        instanceUUID)
                 log.info("Running %s" % cmd)
                 d = yield client.run(cmd, timeout=timeout)
 

--- a/ZenPacks/zenoss/OpenStackInfrastructure/modeler/plugins/zenoss/cmd/linux/openstack/nova.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/modeler/plugins/zenoss/cmd/linux/openstack/nova.py
@@ -54,10 +54,14 @@ class nova(PythonPlugin):
         client.connect()
         timeout = device.zCommandCommandTimeout
 
-        cmd = container_cmd_wrapper(
-            device.zOpenStackRunNovaManageInContainer,
-            "nova-manage --version 2>&1"
-        )
+        # host based installation
+        cmd = "nova-manage --version 2>&1"
+        if device.zOpenStackRunNovaManageInContainer:
+            # container based installation
+            cmd = container_cmd_wrapper(
+                device.zOpenStackRunNovaManageInContainer,
+                "nova-manage --version 2>&1"
+            )
         log.info("Running %s" % cmd)
         try:
             d = yield client.run(cmd, timeout=timeout)


### PR DESCRIPTION
zenpack need to work for both host and container based installs.

With merging NFVi branch into develop branch, the zenpack now should
work for both host based install and container based install. This
commit takes care of this, updates README wiki.