### PR TITLE
Put getOrganizer() call in try/except block

### DIFF
--- a/ZenPacks/zenoss/OpenStackInfrastructure/__init__.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/__init__.py
@@ -50,7 +50,11 @@ class ZenPack(schema.ZenPack):
     def _update_plugins(self):
         log.info('Setting zProperty zCollectorPlugins on /Server/SSH/Linux/NovaHost')
         plugins=self.dmd.Devices.getOrganizer('/Server/SSH/Linux').zCollectorPlugins
-        novahost = self.dmd.Devices.getOrganizer('/Server/SSH/Linux/NovaHost')
+        try:
+            novahost = self.dmd.Devices.getOrganizer('/Server/SSH/Linux/NovaHost')
+        except KeyError:
+            log.info('Creating DeviceClass %s' % '/Server/SSH/Linux/NovaHost')
+            novahost = self.dmd.Devices.createOrganizer('/Server/SSH/Linux/NovaHost')
         novahost.zCollectorPlugins = plugins + NOVA_HOST_PLUGINS
 
     def _migrate_productversions(self):

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,9 @@ AUTHOR = "Zenoss"
 LICENSE = "GPLv2"
 NAMESPACE_PACKAGES = [u'ZenPacks', u'ZenPacks.zenoss']
 PACKAGES = [u'ZenPacks', u'ZenPacks.zenoss', u'ZenPacks.zenoss.OpenStackInfrastructure']
-INSTALL_REQUIRES = ['ZenPacks.zenoss.PythonCollector>=1.6.1', 'ZenPacks.zenoss.OpenStack>1.2.2.9']
+INSTALL_REQUIRES = ['ZenPacks.zenoss.PythonCollector>=1.6.1',
+                    'ZenPacks.zenoss.OpenStack>1.2.2.9',
+                    'ZenPacks.zenoss.LinuxMonitor>2.0.0']
 COMPAT_ZENOSS_VERS = ">=4.2.0"
 PREV_ZENPACK_NAME = ""
 # STOP_REPLACEMENTS


### PR DESCRIPTION
ZEN-22977

If the organizer does not exist, create it.
Also make the zenpack depend on LinuxMonitor 2.0.0