### PR TITLE
I can't find a reason for the workaround we were using- at least with…

### DIFF
--- a/ZenPacks/zenoss/OpenStackInfrastructure/resources/Endpoint.js
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/resources/Endpoint.js
@@ -81,28 +81,6 @@ Ext.apply(Zenoss.render, {
         return value.toUpperCase();
     },
 
-    openstack_uid_renderer: function(uid, name) {
-        // Just straight up links to the object.
-        var parts;
-        if (!uid) {
-            return uid;
-        }
-        if (Ext.isObject(uid)) {
-            if (uid.uid && uid.uid.indexOf('/') > -1) {
-                parts = uid.uid.split('/');
-                name = parts[parts.length-1];
-            }
-            else {
-                name = uid.name;
-            }
-            uid = uid.uid;
-        }
-        if (!name) {
-            parts = uid.split('/');
-            name = parts[parts.length-1];
-        }
-        return Zenoss.render.link(null, uid, name);
-    },
 });
 
 

--- a/ZenPacks/zenoss/OpenStackInfrastructure/zenpack.yaml
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/zenpack.yaml
@@ -708,8 +708,8 @@ classes: !ZenPackSpec
     properties:
       proxy_device:
         label: Device
-        # Workaround to link to a different device
-        renderer: Zenoss.render.openstack_uid_renderer
+        type: entity        
+        content_width: 175        
         api_only: true
         api_backendtype: method
     filter_display: false
@@ -892,9 +892,9 @@ classes: !ZenPackSpec
       guestDevice:
       # link to the guest instance, if known
         label: Guest
-        # workaround to link to a different device
+        type: entity
+        content_width: 175
         order: 3.1
-        renderer: Zenoss.render.openstack_uid_renderer
         api_only: true
         api_backendtype: method
       host:


### PR DESCRIPTION
… ZPL's current entity link renderer, it seems to work fine.