### PR TITLE
DynamicView group and weight updates

### DIFF
--- a/ZenPacks/zenoss/OpenStackInfrastructure/configure.zcml
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/configure.zcml
@@ -97,9 +97,17 @@
     <configure zcml:condition="installed ZenPacks.zenoss.DynamicView">
 
         <subscriber
+            zcml:condition="installed ZenPacks.zenoss.LinuxMonitor.LinuxDevice"
+            provides="ZenPacks.zenoss.DynamicView.interfaces.IRelationsProvider"
+            for="ZenPacks.zenoss.LinuxMonitor.LinuxDevice.LinuxDevice"
+            factory=".dynamicview.LinuxDeviceRelationsProvider_OSI"
+            />
+
+        <subscriber
+            zcml:condition="not-installed ZenPacks.zenoss.LinuxMonitor.LinuxDevice"
             provides="ZenPacks.zenoss.DynamicView.interfaces.IRelationsProvider"
             for="Products.ZenModel.Device.Device"
-            factory=".dynamicview.DeviceRelationsProvider_OSI"
+            factory=".dynamicview.LinuxDeviceRelationsProvider_OSI"
             />
 
         <subscriber

--- a/ZenPacks/zenoss/OpenStackInfrastructure/dynamicview.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/dynamicview.py
@@ -11,7 +11,7 @@ from ZenPacks.zenoss.DynamicView import TAG_ALL, TAG_IMPACTED_BY, TAG_IMPACTS
 from ZenPacks.zenoss.DynamicView.model.adapters import BaseRelationsProvider
 
 
-class DeviceRelationsProvider_OSI(BaseRelationsProvider):
+class LinuxDeviceRelationsProvider_OSI(BaseRelationsProvider):
     def relations(self, type=TAG_ALL):
         if type in (TAG_ALL, TAG_IMPACTED_BY):
             instance = self._adapted.openstackInstance()

--- a/ZenPacks/zenoss/OpenStackInfrastructure/zenpack.yaml
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/zenpack.yaml
@@ -1602,6 +1602,8 @@ classes: !ZenPackSpec
     # --------------------------------------------------------------------------
     impacted_by: [osprocess_component]
     dynamicview_views: [service_view, openstack_view]
+    dynamicview_group: Cinder Services
+    dynamicview_weight: 266
     dynamicview_relations:
       impacted_by: [hostedOn]
       impacts: [orgComponent]
@@ -1618,6 +1620,8 @@ classes: !ZenPackSpec
     # --------------------------------------------------------------------------
     impacted_by: [osprocess_component]
     dynamicview_views: [service_view, openstack_view]
+    dynamicview_group: Cinder APIs
+    dynamicview_weight: 265
     dynamicview_relations:
       impacted_by: [hostedOn]
       impacts: [orgComponent]
@@ -1678,6 +1682,8 @@ classes: !ZenPackSpec
 #        label_width: 50
 #        content_width: 50
     dynamicview_views: [service_view, openstack_view]
+    dynamicview_group: Volumes
+    dynamicview_weight: 242
     dynamicview_relations:
       impacts: [instance, volSnapshots, tenant]
     # --------------------------------------------------------------------------
@@ -1734,6 +1740,8 @@ classes: !ZenPackSpec
         label_width: 80
         content_width: 80
     dynamicview_views: [service_view, openstack_view]
+    dynamicview_group: Snapshots
+    dynamicview_weight: 241
     dynamicview_relations:
       impacted_by: [volume]
     # --------------------------------------------------------------------------


### PR DESCRIPTION
- New, higher-weight, group for Linux devices that are OpenStack hosts
- Add weights for CinderApi, CinderService, Volume, VolSnapshot