### PR TITLE
Remove container names for nova hosts

### DIFF
--- a/ZenPacks/zenoss/OpenStackInfrastructure/zenpack.yaml
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/zenpack.yaml
@@ -78,9 +78,9 @@ device_classes: !ZenPackSpec
     zProperties:
       zOpenStackNeutronConfigDir: /etc/neutron
       zSshConcurrentSessions: 5
-      zOpenStackRunNovaManageInContainer: novacompute
-      zOpenStackRunVirshQemuInContainer: novacompute
-      zOpenStackRunNeutronCommonInContainer: neutron_server
+      zOpenStackRunNovaManageInContainer:
+      zOpenStackRunVirshQemuInContainer:
+      zOpenStackRunNeutronCommonInContainer:
   /OpenStack: {}
   /OpenStack/Infrastructure:
     remove: true


### PR DESCRIPTION
Fixes ZEN-23403

Container names are needed only for NFVi, but not for general uses.
Remove them from non-NFVi ZP.