### PR TITLE
Fixes ZEN-23629.

### DIFF
--- a/ZenPacks/zenoss/OpenStackInfrastructure/migrate/RemoveOldEventClassInstances.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/migrate/RemoveOldEventClassInstances.py
@@ -1,0 +1,32 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2016, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+import logging
+
+from Products.ZenModel.migrate.Migrate import Version
+from Products.ZenModel.ZenPack import ZenPackMigration
+
+
+LOG = logging.getLogger('zen.OpenStackInfrastructure.migrate.%s' % __name__)
+
+
+class RemoveOldEventClassInstances(ZenPackMigration):
+    
+    version = Version(2, 2, 0)
+
+    def migrate(self, dmd):
+        baseCls = dmd.Events.Status
+        LOG.info(
+            "Removing old event class instances under %s",
+            baseCls.getPrimaryDmdId())
+
+        baseCls.removeInstances(('openStackCeilometerHeartbeat',))
+
+
+RemoveOldEventClassInstances()

--- a/ZenPacks/zenoss/OpenStackInfrastructure/objects/objects.xml
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/objects/objects.xml
@@ -392,13 +392,13 @@ history
 </object>
 </object>
 </object>
-<!-- ('', 'zport', 'dmd', 'Events', 'Status', 'instances', 'openStackCeilometerHeartbeat') -->
-<object id='/zport/dmd/Events/Status/instances/openStackCeilometerHeartbeat' module='Products.ZenEvents.EventClassInst' class='EventClassInst'>
+<!-- ('', 'zport', 'dmd', 'Events', 'Status', 'Heartbeat', 'instances', 'openStackCeilometerHeartbeat') -->
+<object id='/zport/dmd/Events/Status/Heartbeat/instances/openStackCeilometerHeartbeat' module='Products.ZenEvents.EventClassInst' class='EventClassInst'>
 <property type="string" id="eventClassKey" mode="w" >
 openStackCeilometerHeartbeat
 </property>
 <property type="int" id="sequence" mode="w" >
-12
+10
 </property>
 </object>
 <!-- ('', 'zport', 'dmd', 'Events', 'Status', 'instances', 'openStackIniFileAccess') -->


### PR DESCRIPTION
openStackCeilometerHeartbeat event class instance has been moved to /Events/Status/Heartbeat event class.