### PR TITLE
Fixes ZEN-23665.

### DIFF
--- a/ZenPacks/zenoss/OpenStackInfrastructure/objects/objects.xml
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/objects/objects.xml
@@ -875,7 +875,7 @@ neutron-server
 neutron-server
 </property>
 <property type="string" id="excludeRegex" mode="w" >
-\b(vim|tail|grep|tar|cat|bash)\b
+\b(vim|tail|grep|pgrep|tar|cat|bash)\b
 </property>
 <property type="boolean" id="ignoreParametersWhenModeling" mode="w" >
 False


### PR DESCRIPTION
Exclude pgrep commands from neutron-server process class.