### PR TITLE
Set container zproperties to ''

### DIFF
--- a/ZenPacks/zenoss/OpenStackInfrastructure/zenpack.yaml
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/zenpack.yaml
@@ -78,9 +78,9 @@ device_classes: !ZenPackSpec
     zProperties:
       zOpenStackNeutronConfigDir: /etc/neutron
       zSshConcurrentSessions: 5
-      zOpenStackRunNovaManageInContainer:
-      zOpenStackRunVirshQemuInContainer:
-      zOpenStackRunNeutronCommonInContainer:
+      zOpenStackRunNovaManageInContainer: ''
+      zOpenStackRunVirshQemuInContainer: ''
+      zOpenStackRunNeutronCommonInContainer: ''
   /OpenStack: {}
   /OpenStack/Infrastructure:
     remove: true


### PR DESCRIPTION
Fixes ZEN-23598

Previously they were left to be nothing, equivalent to None.
But then ZenPropertyManager would convert them into 'None'.
Setting them to '' works