### PR TITLE
Wrong zproperty used in libvirt.py

### DIFF
--- a/ZenPacks/zenoss/OpenStackInfrastructure/modeler/plugins/zenoss/cmd/linux/openstack/libvirt.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/modeler/plugins/zenoss/cmd/linux/openstack/libvirt.py
@@ -72,7 +72,7 @@ class libvirt(PythonPlugin):
                 # host based installation
                 cmd = "virsh --readonly -c 'qemu:///system' dumpxml '%s'" % \
                       instanceUUID
-                if device.zOpenStackRunNeutronCommonInContainer:
+                if device.zOpenStackRunVirshQemuInContainer:
                     # container based installation
                     cmd = container_cmd_wrapper(
                         device.zOpenStackRunVirshQemuInContainer,


### PR DESCRIPTION
Fixes ZEN-23784

libvirt is for compute hosts, it should use
zOpenStackRunVirshQemuInContainer,
not zOpenStackRunNeutronCommonInContainer.