### PR TITLE
Remove '@lvm' from host name if it has it

### DIFF
--- a/ZenPacks/zenoss/OpenStackInfrastructure/datasources/CinderServiceStatusDataSource.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/datasources/CinderServiceStatusDataSource.py
@@ -125,8 +125,17 @@ class CinderServiceStatusDataSourcePlugin(PythonDataSourcePlugin):
         data = self.new_data()
 
         for service in result['services']:
+            # on some OpenStack hosts, the host for
+            # cinder-volume has pool name, lvm, attached to it, like:
+            # u'host': u'liberty-allinone.zenoss.loc@lvm', which isn't correct
+            # whereas for cinder-backup and cinder-scheduler host looks like:
+            # u'host': u'liberty-allinone.zenoss.loc', which is correct
+            # remove '@lvm' from host name only if hostname has it
+            host = service['host']
+            if host.endswith('@lvm'):
+                host = host[:host.index('@lvm')]
             service_id = prepId('service-{0}-{1}-{2}'.format(
-                service['binary'], service['host'], service['zone']))
+                service['binary'], host, service['zone']))
 
             data['maps'].append(ObjectMap(
                 modname='ZenPacks.zenoss.OpenStackInfrastructure.CinderService',


### PR DESCRIPTION
Fixes ZEN-23746

hostname for cinder-volume could be like:
'liberty-allinone.zenoss.loc@lvm'. Remove '@lvm from it.