### PR TITLE
Use keystone adminURL by default

### DIFF
--- a/ZenPacks/zenoss/OpenStackInfrastructure/datasources/PerfCeilometerAPIDataSource.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/datasources/PerfCeilometerAPIDataSource.py
@@ -195,7 +195,6 @@ class PerfCeilometerAPIDataSourcePlugin(PythonDataSourcePlugin):
             password=ds0.zCommandPassword,
             auth_url=ds0.zOpenStackAuthUrl,
             project_id=ds0.zOpenStackProjectId,
-            is_admin=True,
         )
 
         results = []

--- a/ZenPacks/zenoss/OpenStackInfrastructure/openstack_helper.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/openstack_helper.py
@@ -35,9 +35,7 @@ class OpenstackHelper(object):
             password=api_key,
             project_id=project_id,
             auth_url=auth_url,
-            is_admin=True
         )
-        yield client.keystone_tenants()
         serviceCatalog = yield client.serviceCatalog()
 
         ep = []


### PR DESCRIPTION
Fixes ZEN-24546

publicURL if adminURL not work; is_admin determined based on
whether adminURL works or not; remove keystone_tenants from
openstack_helper.py; wrap API calls in try/except blocks;
add keystone_version() as a cheap adminURL test.