### PR TITLE
Use adminURL by default

### DIFF
--- a/ZenPacks/zenoss/OpenStackInfrastructure/apiclients/txapiclient.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/apiclients/txapiclient.py
@@ -62,7 +62,7 @@ class APIClient(object):
         self.auth_url = auth_url
         self.project_id = project_id
 
-        self.is_admin = None
+        self.is_admin = False
         self.user_agent = None
         self._token = None
         self._apis = {}

--- a/ZenPacks/zenoss/OpenStackInfrastructure/apiclients/txapiclient.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/apiclients/txapiclient.py
@@ -77,7 +77,7 @@ class APIClient(object):
 
     @property
     def keystone_endpoints(self):
-        if '/v2' in self.auth_url and self.is_admin:
+        if '/v2' in self.auth_url:
             self._admin_only()
         self.user_agent = 'zenoss-keystoneclient'
         return self._apis.setdefault('keystone_endpoints', API(self, '/endpoints'))
@@ -89,21 +89,21 @@ class APIClient(object):
 
     @property
     def keystone_users(self):
-        if '/v2' in self.auth_url and self.is_admin:
+        if '/v2' in self.auth_url:
             self._admin_only()
         self.user_agent = 'zenoss-keystoneclient'
         return self._apis.setdefault('keystone_users', API(self, '/users'))
 
     @property
     def keystone_roles(self):
-        if '/v2' in self.auth_url and self.is_admin:
+        if '/v2' in self.auth_url:
             self._admin_only()
         self.user_agent = 'zenoss-keystoneclient'
         return self._apis.setdefault('keystone_roles', API(self, '/OS-KSADM/roles'))
 
     @property
     def keystone_services(self):
-        if '/v2' in self.auth_url and self.is_admin:
+        if '/v2' in self.auth_url:
             self._admin_only()
         self.user_agent = 'zenoss-keystoneclient'
         return self._apis.setdefault('keystone_services', API(self, '/OS-KSADM/services'))
@@ -116,7 +116,7 @@ class APIClient(object):
 
     def _admin_only(self, api_method='GET'):
         # for Keystone only
-        if self.is_admin is False:
+        if not self.is_admin:
             raise UnauthorizedError("'%s' is only available in the Identity admin API v2.0" % api_method)
 
     @property
@@ -581,8 +581,8 @@ class NotFoundError(APIClientError):
 def main():
     import pprint
 
-    #client = APIClient('demo', 'password', 'http://10.87.209.216:5000/v2.0', 'demo')
-    client = APIClient('admin', 'password', 'http://10.87.209.216:35357/v2.0', 'admin')
+    client = APIClient('demo', 'password', 'http://10.87.209.216:35357/v2.0', 'demo')
+    #client = APIClient('admin', 'password', 'http://10.87.209.216:35357/v2.0', 'admin')
 
     # Keystone
     tenants = {}

--- a/ZenPacks/zenoss/OpenStackInfrastructure/apiclients/txapiclient.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/apiclients/txapiclient.py
@@ -77,7 +77,7 @@ class APIClient(object):
 
     @property
     def keystone_endpoints(self):
-        if '/v2' in self.auth_url and self.is_admin is not None:
+        if '/v2' in self.auth_url and self.is_admin:
             self._admin_only()
         self.user_agent = 'zenoss-keystoneclient'
         return self._apis.setdefault('keystone_endpoints', API(self, '/endpoints'))
@@ -89,21 +89,21 @@ class APIClient(object):
 
     @property
     def keystone_users(self):
-        if '/v2' in self.auth_url and self.is_admin is not None:
+        if '/v2' in self.auth_url and self.is_admin:
             self._admin_only()
         self.user_agent = 'zenoss-keystoneclient'
         return self._apis.setdefault('keystone_users', API(self, '/users'))
 
     @property
     def keystone_roles(self):
-        if '/v2' in self.auth_url and self.is_admin is not None:
+        if '/v2' in self.auth_url and self.is_admin:
             self._admin_only()
         self.user_agent = 'zenoss-keystoneclient'
         return self._apis.setdefault('keystone_roles', API(self, '/OS-KSADM/roles'))
 
     @property
     def keystone_services(self):
-        if '/v2' in self.auth_url and self.is_admin is not None:
+        if '/v2' in self.auth_url and self.is_admin:
             self._admin_only()
         self.user_agent = 'zenoss-keystoneclient'
         return self._apis.setdefault('keystone_services', API(self, '/OS-KSADM/services'))

--- a/ZenPacks/zenoss/OpenStackInfrastructure/datasources/PerfCeilometerAPIDataSource.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/datasources/PerfCeilometerAPIDataSource.py
@@ -195,7 +195,6 @@ class PerfCeilometerAPIDataSourcePlugin(PythonDataSourcePlugin):
             password=ds0.zCommandPassword,
             auth_url=ds0.zOpenStackAuthUrl,
             project_id=ds0.zOpenStackProjectId,
-            is_admin=True,
         )
 
         results = []

--- a/ZenPacks/zenoss/OpenStackInfrastructure/modeler/plugins/zenoss/OpenStackInfrastructure.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/modeler/plugins/zenoss/OpenStackInfrastructure.py
@@ -91,7 +91,7 @@ class OpenStackInfrastructure(PythonPlugin):
             device.zCommandPassword,
             device.zOpenStackAuthUrl,
             device.zOpenStackProjectId,
-            is_admin=True)
+        )
 
         results = {}
 

--- a/ZenPacks/zenoss/OpenStackInfrastructure/openstack_helper.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/openstack_helper.py
@@ -35,9 +35,7 @@ class OpenstackHelper(object):
             password=api_key,
             project_id=project_id,
             auth_url=auth_url,
-            is_admin=True
         )
-        yield client.keystone_tenants()
         serviceCatalog = yield client.serviceCatalog()
 
         ep = []


### PR DESCRIPTION
Fixes ZEN-24546

use publicURL if adminURL not working; determine is_admin by
whether adminURL works or not; remove keystone_tenants from
openstack_helper.py; add keystone_version as a cheap keystone
api call.