### PR TITLE
Change missing hostmap log to debug

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -707,19 +707,18 @@ The absence of IP address is likely a DNS issue.
 
 ;Hosts are duplicated by Name and IP:
 The '''''zOpenStackHostMapSame''''' exist for mapping equivalent hosts. If you have
-an FQDN and IP that are listed seperately you can make a mapping entry that
-takes the form FQDN=IP:
+an FQDN and IP that are listed separately make a device-level mapping
+entry that takes the form FQDN=IP. For example:
 
   my.example.com=10.100.200.222
 
 Note that you must have DNS functioning for '''my.example.com''' to acquire
-its IP address set correctly.
+its IP address and set its manageIp correctly.
 
 ;Hosts are not identified to a pre-existing Linux ID:
-In this case you already
-have a Linux host identified by an ID name. You should use the
-'''''zOpenStackHostMapToId''''' property to set any equivalent hosts to this ID
-value. For example:
+In this case there is already a Linux host identified by an ID name. Use 
+'''''zOpenStackHostMapToId''''' to make a device-level equivalent hosts mapping
+to this ID value. For example:
 
   my.example.com=myID
   10.100.200.222=myID

--- a/ZenPacks/zenoss/OpenStackInfrastructure/hostmap.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/hostmap.py
@@ -113,11 +113,11 @@ class HostMap(object):
             return
 
         if hostref1 not in self.mapping:
-            log.error("assert_same_host(source=%s): %s is not a valid host reference -- ignoring", source, hostref1)
+            log.warning("assert_same_host(source=%s): %s is not a valid host reference -- ignoring", source, hostref1)
             return
 
         if hostref2 not in self.mapping:
-            log.error("assert_same_host(source=%s): %s is not a valid host reference -- ignoring", source, hostref2)
+            log.warning("assert_same_host(source=%s): %s is not a valid host reference -- ignoring", source, hostref2)
             return
 
         self.asserted_same[hostref1][hostref2] = source


### PR DESCRIPTION
Fixes ZEN-22373

* Handle errors when zOpenStackHostMapSame set at class level
* Quiet down errors for zOpenStackHost* vars