### PR TITLE
Reorder hostmap checks

### DIFF
--- a/ZenPacks/zenoss/OpenStackInfrastructure/Instance.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/Instance.py
@@ -39,6 +39,8 @@ class Instance(schema.Instance):
     def set_host_name(self, hostname):
         search = self.device().componentSearch
         hypervisors = []
+
+        # Code below may have some bearing on ZEN-24803
         for host in [x.getObject() for x in search(titleOrId=hostname,
                                                    meta_type='OpenStackInfrastructureHost')]:
             if host.hypervisor() and host.titleOrId() == hostname:

--- a/ZenPacks/zenoss/OpenStackInfrastructure/datasources/CinderServiceStatusDataSource.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/datasources/CinderServiceStatusDataSource.py
@@ -141,6 +141,13 @@ class CinderServiceStatusDataSourcePlugin(PythonDataSourcePlugin):
 
         ds0 = config.datasources[0]
 
+        # load in previously modeled mappings..
+        hostmap.thaw_mappings(ds0.params['host_mappings'])
+
+        for service in results['services']:
+            if 'host' in service:
+                hostmap.add_hostref(service['host'], source="nova services")
+
         for mapping in ds0.zOpenStackHostMapToId:
             try:
                 hostref, hostid = mapping.split("=")
@@ -151,16 +158,9 @@ class CinderServiceStatusDataSourcePlugin(PythonDataSourcePlugin):
         for mapping in ds0.zOpenStackHostMapSame:
             try:
                 hostref1, hostref2 = mapping.split("=")
-                hostmap.assert_same_as(hostref1, hostref2)
+                hostmap.assert_same_host(hostref1, hostref2)
             except Exception:
                 log.error("Invalid value in zOpenStackHostMapSame: %s", mapping)
-
-        # load in previously modeled mappings..
-        hostmap.thaw_mappings(ds0.params['host_mappings'])
-
-        for service in results['services']:
-            if 'host' in service:
-                hostmap.add_hostref(service['host'], source="nova services")
 
         # generate host IDs
         yield hostmap.perform_mapping()

--- a/ZenPacks/zenoss/OpenStackInfrastructure/datasources/NovaServiceStatusDataSource.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/datasources/NovaServiceStatusDataSource.py
@@ -139,6 +139,13 @@ class NovaServiceStatusDataSourcePlugin(PythonDataSourcePlugin):
 
         ds0 = config.datasources[0]
 
+        # load in previously modeled mappings..
+        hostmap.thaw_mappings(ds0.params['host_mappings'])
+
+        for service in results['services']:
+            if 'host' in service:
+                hostmap.add_hostref(service['host'], source="nova services")
+
         for mapping in ds0.zOpenStackHostMapToId:
             try:
                 hostref, hostid = mapping.split("=")
@@ -149,16 +156,9 @@ class NovaServiceStatusDataSourcePlugin(PythonDataSourcePlugin):
         for mapping in ds0.zOpenStackHostMapSame:
             try:
                 hostref1, hostref2 = mapping.split("=")
-                hostmap.assert_same_as(hostref1, hostref2)
+                hostmap.assert_same_host(hostref1, hostref2)
             except Exception:
                 log.error("Invalid value in zOpenStackHostMapSame: %s", mapping)
-
-        # load in previously modeled mappings..
-        hostmap.thaw_mappings(ds0.params['host_mappings'])
-
-        for service in results['services']:
-            if 'host' in service:
-                hostmap.add_hostref(service['host'], source="nova services")
 
         # generate host IDs
         yield hostmap.perform_mapping()

--- a/ZenPacks/zenoss/OpenStackInfrastructure/hostmap.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/hostmap.py
@@ -116,11 +116,11 @@ class HostMap(object):
         if hostref1 == hostref2:
             return
 
-        if hostref1 not in self.mapping:
+        if not any(hostref1 in x for x in [self.mapping, self.frozen_mapping]):
             log.warning("assert_same_host(source=%s): %s is not a valid host reference -- ignoring", source, hostref1)
             return
 
-        if hostref2 not in self.mapping:
+        if not any(hostref2 in x for x in [self.mapping, self.frozen_mapping]):
             log.warning("assert_same_host(source=%s): %s is not a valid host reference -- ignoring", source, hostref2)
             return
 


### PR DESCRIPTION
Fixes ZEN-24803

* Reorder hostmap assertions
* Rename hostmap.assert_same_as() -> hostmap.assert_same_host()
* Add hostmap.frozen_mapping to test for host assertion