### PR TITLE
Modify hostmap and modeler for zOpenStackHost*

### DIFF
--- a/ZenPacks/zenoss/OpenStackInfrastructure/datasources/CinderServiceStatusDataSource.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/datasources/CinderServiceStatusDataSource.py
@@ -158,7 +158,7 @@ class CinderServiceStatusDataSourcePlugin(PythonDataSourcePlugin):
         for mapping in ds0.zOpenStackHostMapSame:
             try:
                 hostref1, hostref2 = mapping.split("=")
-                hostmap.assert_same_host(hostref1, hostref2)
+                hostmap.assert_same_host(hostref1, hostref2, source='zOpenStackHostMapSame')
             except Exception:
                 log.error("Invalid value in zOpenStackHostMapSame: %s", mapping)
 

--- a/ZenPacks/zenoss/OpenStackInfrastructure/datasources/NovaServiceStatusDataSource.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/datasources/NovaServiceStatusDataSource.py
@@ -156,7 +156,7 @@ class NovaServiceStatusDataSourcePlugin(PythonDataSourcePlugin):
         for mapping in ds0.zOpenStackHostMapSame:
             try:
                 hostref1, hostref2 = mapping.split("=")
-                hostmap.assert_same_host(hostref1, hostref2)
+                hostmap.assert_same_host(hostref1, hostref2, source='zOpenStackHostMapSame')
             except Exception:
                 log.error("Invalid value in zOpenStackHostMapSame: %s", mapping)
 

--- a/ZenPacks/zenoss/OpenStackInfrastructure/hostmap.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/hostmap.py
@@ -87,6 +87,12 @@ class HostMap(object):
         for hostref, hostid in from_db.iteritems():
             self.frozen_mapping[hostref] = hostid
 
+    def has_hostref(self, hostref):
+        """
+        Check if there exists a hostref in self.mapping
+        """
+        return hostref in self.mapping
+
     def add_hostref(self, hostref, source="Unknown"):
         """
         Notify the host mapper about a host reference.
@@ -94,7 +100,7 @@ class HostMap(object):
 
         self.mapping_complete = False
 
-        if hostref in self.mapping:
+        if self.has_hostref(hostref):
             return
 
         if hostref in self.frozen_mapping:
@@ -113,15 +119,15 @@ class HostMap(object):
         same host.
         """
 
+        if not self.has_hostref(hostref1):
+            log.warning("assert_same_host: (Source=%s): %s is not a valid host reference -- ignoring", source, hostref1)
+            return
+
+        if not self.has_hostref(hostref2):
+            log.warning("assert_same_host: (Source=%s): %s is not a valid host reference -- ignoring", source, hostref2)
+            return
+
         if hostref1 == hostref2:
-            return
-
-        if not any(hostref1 in x for x in [self.mapping, self.frozen_mapping]):
-            log.warning("assert_same_host(source=%s): %s is not a valid host reference -- ignoring", source, hostref1)
-            return
-
-        if not any(hostref2 in x for x in [self.mapping, self.frozen_mapping]):
-            log.warning("assert_same_host(source=%s): %s is not a valid host reference -- ignoring", source, hostref2)
             return
 
         self.asserted_same[hostref1][hostref2] = source
@@ -156,7 +162,7 @@ class HostMap(object):
 
             # If the name and IP are known references, but might not
             # be known to be identical, add that assertion.
-            if name in self.mapping and ip in self.mapping:
+            if self.has_hostref(name) and self.has_hostref(ip):
                 self.assert_same_host(name, ip, source="DNS Resolution")
 
         for ip, hostnames in resolved_by_ip.iteritems():
@@ -164,7 +170,7 @@ class HostMap(object):
             # are interchangeable.  Add those assertions where
             # we have seen both versions of the name.
             for hostref1, hostref2 in itertools.combinations(hostnames, 2):
-                if hostref1 in self.mapping and hostref2 in self.mapping:
+                if self.has_hostref(hostref1) and self.has_hostref(hostref2):
                     self.assert_same_host(hostref1, hostref2, source="Resolve to same IP")
 
         new_mapping = {}
@@ -243,7 +249,7 @@ class HostMap(object):
         if not self.mapping_complete:
             raise Exception("perform_mapping must be called before get_hostid")
 
-        if hostref not in self.mapping:
+        if not self.has_hostref(hostref):
             raise Exception("Host reference %s unrecognized. Ensure that add_hostref(%s) is done before attempting to get_hostid(%s)" % (hostref, hostref, hostref))
 
         return self.mapping[hostref]

--- a/ZenPacks/zenoss/OpenStackInfrastructure/modeler/plugins/zenoss/OpenStackInfrastructure.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/modeler/plugins/zenoss/OpenStackInfrastructure.py
@@ -344,6 +344,7 @@ class OpenStackInfrastructure(PythonPlugin):
             if not mapping: continue
             try:
                 hostref, hostid = mapping.split("=")
+                hostmap.add_hostref(hostref, source="zOpenStackHostMapToId")
                 hostmap.assert_host_id(hostref, hostid)
             except Exception as ex:
                 log.error("Invalid value in zOpenStackHostMapToId: '%s'", mapping)
@@ -352,6 +353,8 @@ class OpenStackInfrastructure(PythonPlugin):
             if not mapping: continue
             try:
                 hostref1, hostref2 = mapping.split("=")
+                hostmap.add_hostref(hostref1, source="zOpenStackHostMapSame")
+                hostmap.add_hostref(hostref2, source="zOpenStackHostMapSame")
                 hostmap.assert_same_host(hostref1, hostref2)
             except Exception as ex:
                 log.error("assert_same_host error: %s", ex)

--- a/ZenPacks/zenoss/OpenStackInfrastructure/utils.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/utils.py
@@ -166,6 +166,8 @@ def result_errmsg(result):
             return 'connection refused'
         elif result.type == TimeoutError:
             return 'connection timeout'
+        elif result.type == KeyError:
+            return 'Key Error: {}'.format(result.getErrorMessage())
         else:
             return result.getErrorMessage()
     except AttributeError:


### PR DESCRIPTION
Fixes ZEN-25262

* Use has_mapping() in hostmap
* Add hostrefs to modeler sections for zOpenStackHost* props
* Revert frozen_mapping checks for validation of hosts.