### PR TITLE
Prevent AMQP queues from being deleted

### DIFF
--- a/ZenPacks/zenoss/OpenStackInfrastructure/configure.zcml
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/configure.zcml
@@ -63,13 +63,13 @@
     </configure>
 
     <!-- Endpoint cleanup -->
+    <!-- Commented out: Fixes ZEN-24803. Prevent queues from being deleted.
     <subscriber
         for="ZenPacks.zenoss.OpenStackInfrastructure.Endpoint.Endpoint
              OFS.interfaces.IObjectWillBeMovedEvent"
         handler=".Endpoint.onDeviceDeleted"
         />
-
-
+    -->
 
     <!-- DeviceProxyComponent cleanup -->
     <subscriber


### PR DESCRIPTION
Fixes ZEN-24803

* Prevent queues from being delete when device is removed/re-added