### PR TITLE
Prevent AMQP queues from being deleted

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -734,6 +734,7 @@ to this ID value. For example:
 
 ;2.3.0
 * Added support for Mitaka.
+* ZEN-24803: Prevent Queue removal upon device deletion and recreation
 
 ;2.2.0
 * Added Cinder block storage components.

--- a/ZenPacks/zenoss/OpenStackInfrastructure/configure.zcml
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/configure.zcml
@@ -63,13 +63,13 @@
     </configure>
 
     <!-- Endpoint cleanup -->
+    <!-- Commented out: Fixes ZEN-24803. Prevent queues from being deleted.
     <subscriber
         for="ZenPacks.zenoss.OpenStackInfrastructure.Endpoint.Endpoint
              OFS.interfaces.IObjectWillBeMovedEvent"
         handler=".Endpoint.onDeviceDeleted"
         />
-
-
+    -->
 
     <!-- DeviceProxyComponent cleanup -->
     <subscriber


### PR DESCRIPTION
Fixes ZEN-24803

* Prevent queues from being delete when device is removed/re-added