### PR TITLE
Add limited incremental vNIC modeling

### DIFF
--- a/ZenPacks/zenoss/OpenStackInfrastructure/resources/Endpoint.js
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/resources/Endpoint.js
@@ -78,7 +78,10 @@ Ext.apply(Zenoss.render, {
     },
 
     openstack_uppercase_renderer: function(value) {
-        return value.toUpperCase();
+        if value == null:
+            return ""
+        else:
+            return value.toUpperCase();
     },
 
 });


### PR DESCRIPTION
When perf data is received from ceilometer that seems to refer to a
vNIC we haven't yet seen (because vnic modeling only happens when zenmodeler
re-models the linux device), go ahead and create the vNIC component.

This will allow perf data to be collected starting with the next
data collection cycle.