### PR TITLE
Fixes ZPS-1244: problems modeling openstack environments where hosts have .localdomain names

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -734,6 +734,7 @@ to this ID value. For example:
 
 ;2.3.3
 * Fix error in modeler when neutron agent extension is not available (ZPS-1243)
+* Fix certain problems modeling openstack environments where hosts have .localdomain names (ZPS-1244)
 
 ;2.3.2
 * Wrap brain.getObject() into try/except block (ZPS-442)

--- a/ZenPacks/zenoss/OpenStackInfrastructure/DeviceProxyComponent.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/DeviceProxyComponent.py
@@ -26,7 +26,7 @@ from Products.ZenUtils.Utils import monkeypatch
 from Products.Zuul.interfaces import ICatalogTool
 from Products.AdvancedQuery import Eq
 from Products.DataCollector.ApplyDataMap import ApplyDataMap
-from Products.ZenUtils.IpUtil import getHostByName
+from Products.ZenUtils.IpUtil import getHostByName, IpAddressError
 
 
 def onDeviceDeleted(object, event):
@@ -176,7 +176,11 @@ class DeviceProxyComponent(schema.DeviceProxyComponent):
             device = self.proxy_deviceclass().createInstance(device_name)
             device.setProdState(self.productionState)
             device.setPerformanceMonitor(self.getPerformanceServer().id)
-            device.setManageIp()
+            try:
+                device.setManageIp()
+            except IpAddressError:
+                LOG.warning("Unable to set management IP based on %s", device_name)
+
 
         device.index_object()
         notify(IndexingEvent(device))

--- a/ZenPacks/zenoss/OpenStackInfrastructure/hostmap.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/hostmap.py
@@ -158,6 +158,10 @@ class HostMap(object):
         resolved_by_ip = defaultdict(set)
         for name, ip in resolved.iteritems():
             if ip is not None:
+                if ip.startswith("127."):
+                    log.debug("  %s resolves to an apparent local IP (%s) - ignoring it.", name, ip)
+                    continue
+
                 resolved_by_ip[ip].add(name)
 
             # If the name and IP are known references, but might not


### PR DESCRIPTION
Ignore local IP addresses in hostmap
Suppress errors during setManageIp on proxy devices.