### PR TITLE
Fixes ZPS-1709: A single host can sometimes be modeled as multiple ho…

### DIFF
--- a/ZenPacks/zenoss/OpenStackInfrastructure/datasources/PerfAMQPDataSource.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/datasources/PerfAMQPDataSource.py
@@ -154,7 +154,7 @@ class PerfAMQPDataSourcePlugin(AMQPDataSourcePlugin):
 
     @inlineCallbacks
     def collect(self, config):
-        log.debug("Collect for OpenStack AMQP (%s)" % config.id)
+        log.debug("Collect for OpenStack AMQP Perf (%s)" % config.id)
 
         data = yield super(PerfAMQPDataSourcePlugin, self).collect(config)
         device_id = config.configId

--- a/ZenPacks/zenoss/OpenStackInfrastructure/tests/test_hostmap.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/tests/test_hostmap.py
@@ -2,7 +2,7 @@
 
 ##############################################################################
 #
-# Copyright (C) Zenoss, Inc. 2016, all rights reserved.
+# Copyright (C) Zenoss, Inc. 2016-2017, all rights reserved.
 #
 # This content is made available according to terms specified in
 # License.zenoss under the directory where your Zenoss product is installed.
@@ -49,7 +49,10 @@ class TestHostMap(BaseTestCase):
                 'test2': '1.2.3.5',
                 'test2.example.com': '1.2.3.5',
                 'test1.localdomain': '127.0.0.1',
-                'test2.localdomain': '127.0.0.1'
+                'test2.localdomain': '127.0.0.1',
+
+                'ip-10-111-5-173': '10.111.5.173',
+                'ip-10-111-5-173.zenoss.loc': '10.111.5.173'
             })
         self._real_resolve_names = hostmap.resolve_names
         hostmap.resolve_names = resolve_names
@@ -149,6 +152,24 @@ class TestHostMap(BaseTestCase):
 
         # We want this to resolve to two host IDs, not be consolidated into one.
         self.assertEquals(len(hostmap.all_hostids()), 2)
+
+    def test_mixed_fqdns(self):
+        # This is replicating results seen in the QA environment where
+        # one host was being identified as 2, due to a mix of fqdn and short
+        # names being reported in the nova services list.  (ZPS-1709)
+        hostmap = HostMap()
+
+        hostmap.add_hostref("ip-10-111-5-173", source="nova services")
+        hostmap.add_hostref("ip-10-111-5-173.zenoss.loc", source="nova services")
+        hostmap.add_hostref("ip-10-111-5-173@lvm", source="cinder services")
+        hostmap.add_hostref("ip-10-111-5-173.zenoss.loc@lvm", source="cinder services")
+        hostmap.add_hostref("10.111.5.173", source="Nova API URL")
+
+        self.perform_mapping(hostmap)
+
+        # We want this to consolidated into one hostid.
+        self.assertEquals(len(hostmap.all_hostids()), 1)
+
 
 def test_suite():
     from unittest import TestSuite, makeSuite


### PR DESCRIPTION
…sts despite them resolving to the same IP

Address situation where host "same as" needed to be transitive- that is,
host A is the same as host B, host B is the same as host C, so
host A, B, and C are all the same.

Add unit test for the exact scenario and add more logging to hostmap
for troubleshooting.