### PR TITLE
Fix modeling of openstack versions starting with Newton

### DIFF
--- a/ZenPacks/zenoss/OpenStackInfrastructure/migrate/RemoveOldProducts.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/migrate/RemoveOldProducts.py
@@ -1,0 +1,50 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2017, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+
+import logging
+log = logging.getLogger("zen.migrate")
+
+import Globals
+from Products.ZenModel.migrate.Migrate import Version
+from Products.ZenModel.ZenPack import ZenPackMigration
+from Products.ZenUtils.Utils import unused
+unused(Globals)
+
+# in previous versions of the zenpack, these products were created, but
+# they are no longer needed.
+
+remove_products = [
+    '2016.1',
+    '2016.2',
+    '2017.1',
+    '2017.2',
+    'Newton (2016.2)',
+    'Newton (2017.1)',
+    'Ocata (2017.1)'
+]
+
+
+class RemoveOldProducts(ZenPackMigration):
+    version = Version(2, 4, 0)
+
+    def migrate(self, pack):
+        dmd = pack.dmd
+
+        count = 0
+        current_products = dmd.Manufacturers.OpenStack.products.objectIds()
+        for product in remove_products:
+            if product in current_products:
+                dmd.Manufacturers.OpenStack.manage_deleteProducts(ids=[product])
+                count += 1
+
+        if count:
+            log.info("Removed %d obsolete product objects", count)
+
+RemoveOldProducts()

--- a/ZenPacks/zenoss/OpenStackInfrastructure/modeler/plugins/zenoss/cmd/linux/openstack/nova.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/modeler/plugins/zenoss/cmd/linux/openstack/nova.py
@@ -1,7 +1,7 @@
 ###########################################################################
 #
 # This program is part of Zenoss Core, an open source monitoring platform.
-# Copyright (C) 2014, Zenoss Inc.
+# Copyright (C) 2014-2017, Zenoss Inc.
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 or (at your
@@ -25,6 +25,31 @@ from ZenPacks.zenoss.OpenStackInfrastructure.ssh import SSHClient
 add_local_lib_path()
 
 import re
+
+def get_productKey(version):
+    VERSION_MAP = [
+        # in order versions, we used the returned version as the product key
+        ('2013',   version),   # Havana
+        ('2014.1', version),   # Icehouse
+        ('2014.2', version),   # Juno
+        ('2015.1', version),   # Kilo
+        ('2015.2', version),   # Liberty
+        ('2016.1', version),   # Mitaka
+
+        # Moving forward, we are using the product name as the product key.
+        # This will automatically create new products with that name, as well,
+        # if we don't include them in objects.xml, so that's a nice side effect.
+        ('14',    'Newton'),
+        ('15',    'Ocata'),
+        ('16',    'Pike'),
+    ]
+
+    for prefix, productKey in VERSION_MAP:
+        if version.startswith(prefix):
+            return productKey
+
+    # Unrecognized?  Well, just return the version and we'll use that.
+    return version
 
 
 class nova(PythonPlugin):
@@ -88,9 +113,10 @@ class nova(PythonPlugin):
             match = matcher.search(line)
             if match:
                 version = match.group('version')
+                productKey = get_productKey(version)
                 openstack_om = ObjectMap({
                     'compname': 'os',
-                    'setProductKey': MultiArgs(version, 'OpenStack')
+                    'setProductKey': MultiArgs(productKey, 'OpenStack')
                 })
 
                 return [ObjectMap({

--- a/ZenPacks/zenoss/OpenStackInfrastructure/objects/objects.xml
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/objects/objects.xml
@@ -502,50 +502,6 @@ http://www.openstack.org/
 []
 </property>
 <tomanycont id='products'>
-<object id='2016.1' module='Products.ZenModel.SoftwareClass' class='SoftwareClass'>
-<property type="string" id="name" mode="w" >
-2016.1
-</property>
-<property type="lines" id="productKeys" mode="w" >
-['2016.1.1', '2016.1.2', '2016.1.3', '2016.1.4', '2016.1.5', '2016.1.6', '2016.1.7', '2016.1.8', '2016.1.9', '2016.1.10']
-</property>
-<property type="boolean" id="isOS" mode="w" >
-True
-</property>
-</object>
-<object id='2016.2' module='Products.ZenModel.SoftwareClass' class='SoftwareClass'>
-<property type="string" id="name" mode="w" >
-2016.2
-</property>
-<property type="lines" id="productKeys" mode="w" >
-['2016.2.1', '2016.2.2', '2016.2.3', '2016.2.4', '2016.2.5', '2016.2.6', '2016.2.7', '2016.2.8', '2016.2.9', '2016.2.10']
-</property>
-<property type="boolean" id="isOS" mode="w" >
-True
-</property>
-</object>
-<object id='2017.1' module='Products.ZenModel.SoftwareClass' class='SoftwareClass'>
-<property type="string" id="name" mode="w" >
-2017.1
-</property>
-<property type="lines" id="productKeys" mode="w" >
-['2017.1.1', '2017.1.2', '2017.1.3', '2017.1.4', '2017.1.5', '2017.1.6', '2017.1.7', '2017.1.8', '2017.1.9', '2017.1.10']
-</property>
-<property type="boolean" id="isOS" mode="w" >
-True
-</property>
-</object>
-<object id='2017.2' module='Products.ZenModel.SoftwareClass' class='SoftwareClass'>
-<property type="string" id="name" mode="w" >
-2017.2
-</property>
-<property type="lines" id="productKeys" mode="w" >
-['2017.2.1', '2017.2.2', '2017.2.3', '2017.2.4', '2017.2.5', '2017.2.6', '2017.2.7', '2017.2.8', '2017.2.9', '2017.2.10']
-</property>
-<property type="boolean" id="isOS" mode="w" >
-True
-</property>
-</object>
 <object id='Havana (2013.2)' module='Products.ZenModel.SoftwareClass' class='SoftwareClass'>
 <property type="string" id="name" mode="w" >
 Havana (2013.2)
@@ -607,28 +563,6 @@ Mitaka (2016.1)
 </property>
 <property type="lines" id="productKeys" mode="w" >
 ['2016.1.1', '2016.1.2', '2016.1.3', '2016.1.4', '2016.1.5', '2016.1.6', '2016.1.7', '2016.1.8', '2016.1.9', '2016.1.10']
-</property>
-<property type="boolean" id="isOS" mode="w" >
-True
-</property>
-</object>
-<object id='Newton (2016.2)' module='Products.ZenModel.SoftwareClass' class='SoftwareClass'>
-<property type="string" id="name" mode="w" >
-Newton (2016.2)
-</property>
-<property type="lines" id="productKeys" mode="w" >
-['2016.2.1', '2016.2.2', '2016.2.3', '2016.2.4', '2016.2.5', '2016.2.6', '2016.2.7', '2016.2.8', '2016.2.9', '2016.2.10']
-</property>
-<property type="boolean" id="isOS" mode="w" >
-True
-</property>
-</object>
-<object id='Ocata (2017.1)' module='Products.ZenModel.SoftwareClass' class='SoftwareClass'>
-<property type="string" id="name" mode="w" >
-Newton (2017.1)
-</property>
-<property type="lines" id="productKeys" mode="w" >
-['2017.1.1', '2017.1.2', '2017.1.3', '2017.1.4', '2017.1.5', '2017.1.6', '2017.1.7', '2017.1.8', '2017.1.9', '2017.1.10']
 </property>
 <property type="boolean" id="isOS" mode="w" >
 True


### PR DESCRIPTION
* Removed predefined products for newton onward
* Switched the nova modeler to handle mapping from version to name instead.

Fixes ZEN-24854