### PR TITLE
Remove zOpenStackCeilometerUrl and related code, which has never been…

### DIFF
--- a/ZenPacks/zenoss/OpenStackInfrastructure/api.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/api.py
@@ -59,22 +59,18 @@ def _runcommand(cmd):
 
 class IOpenStackInfrastructureFacade(IFacade):
     def addOpenStack(self, device_name, username, api_key, project_id, auth_url,
-                     ceilometer_url, region_name=None, collector='localhost'):
+                     region_name=None, collector='localhost'):
         """Add OpenStack Endpoint."""
 
     def getRegions(self, username, api_key, project_id, auth_url):
         """Get a list of available regions, given a keystone endpoint and credentials."""
-
-    def getCeilometerUrl(self, username, api_key, project_id, auth_url, region_name):
-        """Return the first defined ceilometer URL, given a keystone endpoint,
-        credentials, and a region.  May return an empty string if none is found."""
 
 
 class OpenStackInfrastructureFacade(ZuulFacade):
     implements(IOpenStackInfrastructureFacade)
 
     def addOpenStack(self, device_name, username, api_key, project_id, auth_url,
-                     ceilometer_url, region_name, collector='localhost'):
+                     region_name, collector='localhost'):
         """Add a new OpenStack endpoint to the system."""
         parsed_url = urlparse(auth_url.strip())
 
@@ -93,7 +89,6 @@ class OpenStackInfrastructureFacade(ZuulFacade):
             'zOpenStackProjectId': project_id,
             'zOpenStackAuthUrl': auth_url.strip(),
             'zOpenStackRegionName': region_name,
-            'zOpenStackCeilometerUrl': ceilometer_url
             }
 
         @transact
@@ -133,30 +128,17 @@ class OpenStackInfrastructureFacade(ZuulFacade):
 
         return _runcommand(cmd)
 
-    def getCeilometerUrl(self, username, api_key, project_id, auth_url, region_name):
-        """Return the first defined ceilometer URL, given a keystone endpoint,
-        credentials, and a region.  May return an empty string if none is found."""
-
-        cmd = [_helper, "getCeilometerUrl"]
-        cmd.append("--username=%s" % username)
-        cmd.append("--api_key=%s" % api_key)
-        cmd.append("--project_id=%s" % project_id)
-        cmd.append("--auth_url=%s" % auth_url)
-        cmd.append("--region_name=%s" % region_name)
-
-        return _runcommand(cmd)
-
 
 class OpenStackInfrastructureRouter(DirectRouter):
     def _getFacade(self):
         return Zuul.getFacade('openstackinfrastructure', self.context)
 
     def addOpenStack(self, device_name, username, api_key, project_id, auth_url,
-                     ceilometer_url, region_name, collector='localhost'):
+                     region_name, collector='localhost'):
 
         facade = self._getFacade()
         success, message = facade.addOpenStack(
-            device_name, username, api_key, project_id, auth_url, ceilometer_url,
+            device_name, username, api_key, project_id, auth_url,
             region_name=region_name, collector=collector)
 
         if success:
@@ -168,10 +150,4 @@ class OpenStackInfrastructureRouter(DirectRouter):
         facade = self._getFacade()
 
         data = facade.getRegions(username, api_key, project_id, auth_url)
-        return DirectResponse(success=True, data=data)
-
-    def getCeilometerUrl(self, username, api_key, project_id, auth_url, region_name):
-        facade = self._getFacade()
-
-        data = facade.getCeilometerUrl(username, api_key, project_id, auth_url, region_name)
         return DirectResponse(success=True, data=data)

--- a/ZenPacks/zenoss/OpenStackInfrastructure/datasources/PerfCeilometerAPIDataSource.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/datasources/PerfCeilometerAPIDataSource.py
@@ -156,7 +156,6 @@ class PerfCeilometerAPIDataSourcePlugin(PythonDataSourcePlugin):
     proxy_attributes = ('zCommandUsername',
                         'zCommandPassword',
                         'zOpenStackAuthUrl',
-                        'zPerfCeilometerAPIUrl',
                         'zOpenStackProjectId',
                         'zOpenStackRegionName',
                         'resourceId')

--- a/ZenPacks/zenoss/OpenStackInfrastructure/deviceloaders.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/deviceloaders.py
@@ -26,7 +26,7 @@ class OpenStackInfrastructureLoader(object):
 
     Sample usage:
 
-    /Devices/OpenStack/Infrastructure loader='openstackinfrastructure', loader_arg_keys=['deviceName', 'username', 'api_key', 'project_id', 'auth_url', 'ceilometer_url', 'region_name', 'collector']
+    /Devices/OpenStack/Infrastructure loader='openstackinfrastructure', loader_arg_keys=['deviceName', 'username', 'api_key', 'project_id', 'auth_url', 'region_name', 'collector']
         ostack_test username='admin', api_key='admin_password', project_id='admin', auth_url='http://10.1.2.3:5000/v2.0/', region_name='RegionOne'
 
     """
@@ -35,6 +35,9 @@ class OpenStackInfrastructureLoader(object):
     def load_device(self, dmd, deviceName, username, api_key, project_id, auth_url,
                     ceilometer_url=None, region_name=None, collector='localhost'):
 
+        # we accept, but do not use, the ceilometer_url parameter for backwards
+        # compatability reasons.
+
         return getFacade('openstackinfrastructure', dmd).addOpenStack(
-            deviceName, username, api_key, project_id, auth_url, ceilometer_url,
+            deviceName, username, api_key, project_id, auth_url,
             region_name=region_name, collector=collector)

--- a/ZenPacks/zenoss/OpenStackInfrastructure/migrate/RemoveOldZProps.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/migrate/RemoveOldZProps.py
@@ -1,0 +1,45 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2017, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+
+import logging
+log = logging.getLogger("zen.migrate")
+
+import Globals
+from Products.ZenModel.migrate.Migrate import Version
+from Products.ZenModel.ZenPack import ZenPackMigration
+from Products.ZenUtils.Utils import unused
+unused(Globals)
+
+# in previous versions of the zenpack, these zproperties were created, but
+# they are no longer needed.
+
+remove_zproperties = [
+    'zOpenStackCeilometerUrl'
+]
+
+
+class RemoveOldZProps(ZenPackMigration):
+    version = Version(2, 4, 0)
+
+    def migrate(self, pack):
+        dmd = pack.dmd
+
+        count = 0
+        for prop in remove_zproperties:
+            if dmd.Devices.hasProperty(prop):
+                dmd.Devices._delProperty(prop)
+                count += 1
+
+        if count == 1:
+            log.info("Removed %d obsolete zProperty", count)
+        elif count:
+            log.info("Removed %d obsolete zProperties", count)
+
+RemoveOldZProps()

--- a/ZenPacks/zenoss/OpenStackInfrastructure/openstack_helper.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/openstack_helper.py
@@ -44,30 +44,6 @@ class OpenstackHelper(object):
 
         returnValue([{'key': c, 'label': c} for c in sorted(regions)])
 
-    @inlineCallbacks
-    def getCeilometerUrl(self, username, api_key, project_id, auth_url, region_name):
-        """Return the first defined ceilometer URL, given a keystone endpoint,
-        credentials, and a region.  May return an empty string if none is found."""
-
-        client = APIClient(
-            username=username,
-            password=api_key,
-            project_id=project_id,
-            auth_url=auth_url,
-        )
-
-        serviceCatalog = yield client.serviceCatalog()
-
-        for sc in serviceCatalog:
-            if sc['type'] == 'metering':
-                for endpoint in sc['endpoints']:
-                    if endpoint['region'] == region_name:
-                        returnValue(str(endpoint['publicURL']))
-                        return
-
-        # never found one.
-        returnValue("")
-
 
 if __name__ == '__main__':
     from twisted.internet import reactor
@@ -80,7 +56,6 @@ if __name__ == '__main__':
 
     supported_methods = {
         'getRegions': ('username', 'api_key', 'project_id', 'auth_url',),
-        'getCeilometerUrl': ('username', 'api_key', 'project_id', 'auth_url', 'region_name',)
     }
 
     if methodname in supported_methods:

--- a/ZenPacks/zenoss/OpenStackInfrastructure/resources/global.js
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/resources/global.js
@@ -147,32 +147,11 @@ var addOpenStack = new Zenoss.Action({
                         editable: false,
                         allowBlank: false,
                         triggerAction: 'all',
-                        selectOnFocus: false,
-                        listeners: {
-                            select: this.updateCeilometer,
-                            scope: this
-                        }
+                        selectOnFocus: false
                     },{
                         xtype: 'label',
                         style: 'font-style: italic',
                         text: '(OS_REGION_NAME)',
-                        margin: '0 0 0 10'
-                    }]
-                }, {
-                    xtype: 'container',
-                    layout: 'hbox',
-                    items: [{
-                        xtype: 'textfield',
-                        name: 'ceilometer_url',
-                        fieldLabel: _t('Ceilometer URL'),
-                        labelWidth: 120,
-                        id: "openstack_ceilometer_url",
-                        width: 350,
-                        allowBlank: true
-                    },{
-                        xtype: 'label',
-                        style: 'font-style: italic',
-                        text: '',
                         margin: '0 0 0 10'
                     }]
                 }, {
@@ -258,31 +237,8 @@ var addOpenStack = new Zenoss.Action({
         } else {
             store.removeAll()
         }
-    },
-
-    updateCeilometer: function () {
-        form = Ext.getCmp('addopenstackinfrastructure-form').getForm();
-        formvalues = form.getFieldValues();
-        ceil_url = Ext.getCmp('openstack_ceilometer_url');
-
-        if (formvalues.username && formvalues.api_key && formvalues.project_id && 
-            formvalues.auth_url && formvalues.region_name && ! formvalues.ceilometer_url) {
-
-            Zenoss.remote.OpenStackInfrastructureRouter.getCeilometerUrl({
-                    username: formvalues.username,
-                    api_key: formvalues.api_key,
-                    project_id: formvalues.project_id,
-                    auth_url: formvalues.auth_url,
-                    region_name: formvalues.region_name
-                },
-                function(response) {
-                    if (response.success) {
-                        ceil_url.setValue(response.data);
-                    }                            
-                }
-            );
-        }
     }
+
 });
 
 // Push the addOpenStack action to the adddevice button

--- a/ZenPacks/zenoss/OpenStackInfrastructure/zenpack.yaml
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/zenpack.yaml
@@ -2,7 +2,6 @@ name: ZenPacks.zenoss.OpenStackInfrastructure
 zProperties: !ZenPackSpec
   DEFAULTS:
     category: OpenStack
-  zOpenStackCeilometerUrl: {}
   zOpenStackExtraHosts:
     type: lines
   zOpenStackHostDeviceClass:

--- a/docs/body.md
+++ b/docs/body.md
@@ -280,7 +280,7 @@ where <filename> should have the form:
 
 ```
 /Devices/OpenStack/Infrastructure loader='openstackinfrastructure',\
-    loader_arg_keys=['deviceName', 'username', 'api_key', 'project_id', 'auth_url', 'ceilometer_url', 'region_name', 'collector']
+    loader_arg_keys=['deviceName', 'username', 'api_key', 'project_id', 'auth_url', 'region_name', 'collector']
 <devicename> username='<username>', api_key='<password>', project_id='<tenant ID>', \
     auth_url='http://<ip address>:5000/v2.0/', region_name='RegionOne'
 


### PR DESCRIPTION
… used, and never will be at this point, since the ceilometer API is deprecated.