### PR TITLE
Remove @transact decorator on create_proxy_device to avoid nesting transactions

### DIFF
--- a/ZenPacks/zenoss/OpenStackInfrastructure/DeviceProxyComponent.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/DeviceProxyComponent.py
@@ -16,7 +16,6 @@ LOG = logging.getLogger('zen.OpenStackDeviceProxyComponent')
 from zope.event import notify
 from zope.interface import implements
 
-from ZODB.transact import transact
 from OFS.interfaces import IObjectWillBeAddedEvent, IObjectWillBeMovedEvent
 from Products.Zuul.catalog.events import IndexingEvent
 from Products.ZenEvents.interfaces import IPostEventPlugin
@@ -32,8 +31,8 @@ from Products.ZenUtils.IpUtil import getHostByName, IpAddressError
 def onDeviceDeleted(object, event):
     '''
     Clean up the dangling reference to a device if that device has been removed.
-    (Note: we may re-create the device automatically next time someone tries to access
-    self.proxy_device, though)
+    (Note: we may re-create the device automatically next time someone calls
+    self.ensure_proxy_device, though)
     '''
     if not IObjectWillBeAddedEvent.providedBy(event) and not IObjectWillBeMovedEvent.providedBy(event):
         if hasattr(object, 'openstackProxyComponentUUID'):
@@ -109,14 +108,15 @@ class DeviceProxyComponent(schema.DeviceProxyComponent):
         '''
         Ensure that the proxy device exists, creating it if necessary.
         '''
-        self.proxy_device()
+        if not self.proxy_device():
+            self.create_proxy_device()
 
         return True
 
     def proxy_device(self):
         '''
-        Return this component's corresponding proxy device, creating
-        it in the proxy_deviceclass if it does not exist.
+        Return this component's corresponding proxy device, or None if
+        it does not yet exist.
 
         Default assumes that the names must match.
         '''
@@ -142,11 +142,10 @@ class DeviceProxyComponent(schema.DeviceProxyComponent):
                 self.claim_proxy_device(device)
                 return device
             else:
-                return self.create_proxy_device()
+                return None
         else:
-            return self.create_proxy_device()
+            return None
 
-    @transact
     def create_proxy_device(self):
         '''
         Create a proxy device in the proxy_deviceclass.
@@ -180,7 +179,6 @@ class DeviceProxyComponent(schema.DeviceProxyComponent):
                 device.setManageIp()
             except IpAddressError:
                 LOG.warning("Unable to set management IP based on %s", device_name)
-
 
         device.index_object()
         notify(IndexingEvent(device))
@@ -241,6 +239,7 @@ class DeviceProxyComponent(schema.DeviceProxyComponent):
         if device:
             graphs.extend(device.getGraphObjects())
         return graphs
+
 
 class DeviceLinkProvider(object):
     '''
@@ -327,6 +326,5 @@ class PostEventPlugin(object):
                     except Exception:
                         LOG.debug("Unable to append event for OSProcess %s",
                                   osprocess.osProcessClass().id)
-
 
             eventProxy.tags.addAll('ZenPacks.zenoss.OpenStackInfrastructure.DeviceProxyComponent', tags)

--- a/ZenPacks/zenoss/OpenStackInfrastructure/Host.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/Host.py
@@ -34,12 +34,15 @@ class Host(schema.Host):
 
     def ensure_proxy_device(self):
         # ensure that the host exists.
-        self.proxy_device()
+        device = self.proxy_device()
+        if not device:
+            device = self.create_proxy_device()
+        return device
 
     def ensure_service_monitoring(self):
         # Based on the NovaServices we have modeled on the host, ensure that we
         # have the right OSProcess groups detected.
-        device = self.proxy_device()
+        device = self.ensure_proxy_device()
 
         # If we're getting IPServices directly from the OS (rather than port
         # scannning, there's no good reason to have such a low

--- a/ZenPacks/zenoss/OpenStackInfrastructure/SoftwareComponent.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/SoftwareComponent.py
@@ -18,9 +18,11 @@ class SoftwareComponent(schema.SoftwareComponent):
 
     def osprocess_component(self):
         try:
-            for osprocess in self.hostedOn().proxy_device().getDeviceComponents(type='OSProcess'):
-                if osprocess.osProcessClass().id == self.binary:
-                    return osprocess
+            device = self.hostedOn().proxy_device()
+            if device:
+                for osprocess in device.getDeviceComponents(type='OSProcess'):
+                    if osprocess.osProcessClass().id == self.binary:
+                        return osprocess
         except Exception:
             pass
 

--- a/ZenPacks/zenoss/OpenStackInfrastructure/services/OpenStackService.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/services/OpenStackService.py
@@ -29,10 +29,12 @@ class OpenStackService(HubService):
                     hostnames.add(host.hostfqdn)
 
                 processes = set()
-                for process in host.proxy_device().getDeviceComponents(type='OSProcess'):
-                    process_name = process.osProcessClass().id
-                    if process_name in ('ceilometer-collector'):
-                        processes.add(process_name)
+                linux_device = host.proxy_device()
+                if linux_device:
+                    for process in linux_device.getDeviceComponents(type='OSProcess'):
+                        process_name = process.osProcessClass().id
+                        if process_name in ('ceilometer-collector'):
+                            processes.add(process_name)
 
                 if processes:
                     result.append(dict(

--- a/ZenPacks/zenoss/OpenStackInfrastructure/tests/utils.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/tests/utils.py
@@ -296,7 +296,7 @@ def create_model_data(dmd):
     for component in endpoint.components():
         if isinstance(component, SoftwareComponent):
             binary = component.binary
-            linux_device = component.hostedOn().proxy_device()
+            linux_device = component.hostedOn().ensure_proxy_device()
 
             process_id = '%s_%s' % (linux_device.id, binary)
             process = OSProcess(process_id)


### PR DESCRIPTION

Nesting @transact will cause these types of low level transaction failures.

This function was originally decorated because proxy_device() was allowed to
create devices as a side effect (that is, a read-only operation could
cause a device to come into existance).  The transact decorator was
used to insure that this gets committed, wherever it might happen.

This was a bad idea for multiple reasons, and so now proxy_device() is
allowed to return a None, and the devices are created only when set_maintain_proxydevices
or set_ensure_service_monitoring get called, and are committed through
normal ApplyDataMap transaction.

Everyplace that calls proxy_device, directly or indirectly, should now
handle the possibility of 'None' being returned.  It wasn't really
that big of a deal.