### PR TITLE
Make AMQP datasource's plugin class name not editable

### DIFF
--- a/ZenPacks/zenoss/OpenStackInfrastructure/datasources/AMQPDataSource.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/datasources/AMQPDataSource.py
@@ -25,13 +25,15 @@ from Products.ZenEvents import ZenEventClasses
 import Products.ZenMessaging.queuemessaging
 
 from ZenPacks.zenoss.PythonCollector.datasources.PythonDataSource import (
-    PythonDataSource, PythonDataSourcePlugin, PythonDataSourceInfo,
-    IPythonDataSourceInfo)
+    PythonDataSource, PythonDataSourcePlugin )
 
 from ZenPacks.zenoss.OpenStackInfrastructure.utils import result_errmsg, sleep
 from zenoss.protocols.amqpconfig import AMQPConfig
 from zenoss.protocols.interfaces import IAMQPConnectionInfo, IQueueSchema
 from zenoss.protocols.twisted.amqp import AMQPFactory
+
+from Products.Zuul.infos.template import RRDDataSourceInfo
+from Products.Zuul.interfaces import IRRDDataSourceInfo
 
 # How long to cache data in memory before discarding it (data that
 # is coming from ceilometer, but not consumed by any monitoring templates).
@@ -63,13 +65,13 @@ class AMQPDataSource(PythonDataSource):
         'AMQPDataSource.AMQPDataSourcePlugin'
 
 
-class IAMQPDataSourceInfo(IPythonDataSourceInfo):
+class IAMQPDataSourceInfo(IRRDDataSourceInfo):
     '''
     API Info interface for IAMQPDataSource.
     '''
 
 
-class AMQPDataSourceInfo(PythonDataSourceInfo):
+class AMQPDataSourceInfo(RRDDataSourceInfo):
     '''
     API Info adapter factory for AMQPDataSource.
     '''

--- a/ZenPacks/zenoss/OpenStackInfrastructure/datasources/EventsAMQPDataSource.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/datasources/EventsAMQPDataSource.py
@@ -19,6 +19,9 @@ from zope.component import adapts
 from zope.interface import implements
 
 from Products.ZenEvents import ZenEventClasses
+from Products.Zuul.form import schema
+from Products.Zuul.infos import ProxyProperty
+from Products.Zuul.utils import ZuulMessageFactory as _t
 
 from ZenPacks.zenoss.OpenStackInfrastructure.datasources.AMQPDataSource import (
     AMQPDataSource, AMQPDataSourcePlugin, AMQPDataSourceInfo,
@@ -61,7 +64,10 @@ class IEventsAMQPDataSourceInfo(IAMQPDataSourceInfo):
     API Info interface for IEventsAMQPDataSource.
     '''
 
-    pass
+    cycletime = schema.TextLine(
+        group=_t('OpenStack Ceilometer'),
+        title=_t('Cycletime')
+    )
 
 
 class EventsAMQPDataSourceInfo(AMQPDataSourceInfo):
@@ -71,6 +77,8 @@ class EventsAMQPDataSourceInfo(AMQPDataSourceInfo):
 
     implements(IEventsAMQPDataSourceInfo)
     adapts(EventsAMQPDataSource)
+
+    cycletime = ProxyProperty('cycletime')
 
     testable = False
 

--- a/ZenPacks/zenoss/OpenStackInfrastructure/datasources/PerfAMQPDataSource.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/datasources/PerfAMQPDataSource.py
@@ -74,6 +74,10 @@ class IPerfAMQPDataSourceInfo(IAMQPDataSourceInfo):
         group=_t('OpenStack Ceilometer'),
         title=_t('meter Name'))
 
+    cycletime = schema.TextLine(
+        group=_t('OpenStack Ceilometer'),
+        title=_t('Cycletime')
+    )
 
 class PerfAMQPDataSourceInfo(AMQPDataSourceInfo):
     '''
@@ -82,6 +86,8 @@ class PerfAMQPDataSourceInfo(AMQPDataSourceInfo):
 
     implements(IPerfAMQPDataSourceInfo)
     adapts(PerfAMQPDataSource)
+
+    cycletime = ProxyProperty('cycletime')
 
     testable = False
 


### PR DESCRIPTION
ZPS-4328: Hide plugin class name