### PR TITLE
Allow empty servers image in modeler

### DIFF
--- a/ZenPacks/zenoss/OpenStackInfrastructure/modeler/plugins/zenoss/OpenStackInfrastructure.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/modeler/plugins/zenoss/OpenStackInfrastructure.py
@@ -615,8 +615,9 @@ class OpenStackInfrastructure(PythonPlugin):
 
             # Some Instances are created from pre-existing volumes
             # This implies no image may exists.
-            image_id = server.get('image', {}).get('id')
-            if image_id:
+            image = server.get('image')
+            if image:
+                image_id = image.get('id')
                 server_dict['set_image'] = prepId('image-{0}'.format(image_id))
 
             servers.append(ObjectMap(

--- a/ZenPacks/zenoss/OpenStackInfrastructure/tests/test_model_process_base.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/tests/test_model_process_base.py
@@ -819,6 +819,18 @@ class TestModelProcess(BaseTestCase):
             'set_parentOrg': 'region-RegionOne',
             'title': u'nova'})
 
+    def testBadImages(self):
+        # If server data has an empty image (a missing structure is possible!),
+        # make sure modeler does not fail and omits set_image on object.
+        data = self.data.copy()
+
+        data['servers'][0]['image'] = ''
+        server_id = 'server-' + data['servers'][0]['id']
+
+        for objmap in all_objmaps(self._processTestData(data)):
+            if getattr(objmap, 'id', None) == server_id:
+                self.assertFalse(hasattr(objmap, 'set_image'))
+
 
 def test_suite():
     from unittest import TestSuite, makeSuite


### PR DESCRIPTION
Fixes ZPS-3851 in part

The servers image structure can be an empty string or None.