### PR TITLE
Allow API context-dependent calling per user

### DIFF
--- a/ZenPacks/zenoss/OpenStackInfrastructure/apiclients/txapiclient.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/apiclients/txapiclient.py
@@ -100,6 +100,7 @@ class NovaClient(BaseClient):
     hypervisor_detail_id = api('/os-hypervisors/{param[hypervisor_id]}')
     images = api('/images/detail')
     servers = api('/servers/detail?all_tenants=1')
+    servers_single = api('/servers/detail')
     services = api('/os-services')
 
 
@@ -121,9 +122,12 @@ class CinderClient(BaseClient):
     keystone_service_type = 'volumev2'
 
     volumes = api('/volumes/detail?all_tenants=1')
+    volumes_single = api('/volumes/detail')
     volumetypes = api('/types')
     volumebackups = api('/backups/detail?all_tenants=1')
+    volumebackups_single = api('/backups/detail')
     volumesnapshots = api('/snapshots/detail?all_tenants=1')
+    volumesnapshots_single = api('/snapshots/detail')
     pools = api('/scheduler-stats/get_pools?detail=True')
     quotas = api('/os-quota-sets/{param[tenant]}')
     services = api('/os-services')
@@ -243,6 +247,7 @@ def main():
 
     if reactor.running:
         reactor.stop()
+
 
 if __name__ == '__main__':
     main()

--- a/ZenPacks/zenoss/OpenStackInfrastructure/modeler/plugins/zenoss/OpenStackInfrastructure.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/modeler/plugins/zenoss/OpenStackInfrastructure.py
@@ -1441,6 +1441,10 @@ class OpenStackInfrastructure(PythonPlugin):
             results['hypervisor_details'][hypervisor_id] = hypervisor_detail_id
 
         results['servers'] = yield self.api_call(nova.servers, 'servers')
+        # Retry as single in case where we don't use administrator account.
+        if not results['servers']:
+            LOG.info("API failed for 'servers': Re-trying as single tenant.")
+            results['servers'] = yield self.api_call(nova.servers_single, 'servers')
         results['services'] = yield self.api_call(nova.services, 'services')
         results['agents'] = yield self.api_call(neutron.agents, 'agents')
 
@@ -1506,8 +1510,17 @@ class OpenStackInfrastructure(PythonPlugin):
         results['floatingips'] = yield self.api_call(neutron.floatingips, 'floatingips')
         results['cinder_url'] = yield self.api_call(cinder.get_url, None)
         results['volumes'] = yield self.api_call(cinder.volumes, 'volumes')
+        # Retry as single in case where we don't use administrator account.
+        if not results['volumes']:
+            LOG.info("API failed for 'volumes': Re-trying as single tenant.")
+            results['volumes'] = yield self.api_call(cinder.volumes_single, 'volumes')
+
         results['volumetypes'] = yield self.api_call(cinder.volumetypes, 'volume_types')
         results['volsnapshots'] = yield self.api_call(cinder.volumesnapshots, 'snapshots')
+        # Retry as single in case where we don't use administrator account.
+        if not results['volsnapshots']:
+            LOG.info("API failed for 'volsnapshots': Re-trying as single tenant.")
+            results['volsnapshots'] = yield self.api_call(cinder.volumesnapshots_single, 'snapshots')
         results['cinder_services'] = yield self.api_call(cinder.services, 'services')
         results['volume_pools'] = yield self.api_call(cinder.pools, 'pools')
 

--- a/docs/body.md
+++ b/docs/body.md
@@ -811,6 +811,7 @@ Changes
 
 2.5.0
 
+- Allow non-admin users limited modeling ability (ZPS-3851)
 - Fix KeyError in PerfAMQPDataSource vNIC discovery (ZPS-4661)
 - Guard against missing tenant quota. (ZPS-4627)
 


### PR DESCRIPTION
Fixes ZPS-3851

* API was hard-coded for admin user calls. As we need non-admin users,
  we must allow for context dependent API calling.