### PR TITLE
Allow restricted users for monitoring

### DIFF
--- a/ZenPacks/zenoss/OpenStackInfrastructure/datasources/CinderServiceStatusDataSource.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/datasources/CinderServiceStatusDataSource.py
@@ -20,12 +20,13 @@ from zope.interface import implements
 
 from Products.DataCollector.plugins.DataMaps import ObjectMap
 from Products.ZenEvents import ZenEventClasses
+from Products.ZenUtils.Utils import prepId
 
 from ZenPacks.zenoss.PythonCollector.datasources.PythonDataSource import (
     PythonDataSource, PythonDataSourcePlugin, PythonDataSourceInfo,
     IPythonDataSourceInfo)
 
-from Products.ZenUtils.Utils import prepId
+from ZenPacks.zenoss.OpenStackInfrastructure.apiclients.exceptions import APIClientError
 from ZenPacks.zenoss.OpenStackInfrastructure.hostmap import HostMap
 from ZenPacks.zenoss.OpenStackInfrastructure.utils import result_errmsg, add_local_lib_path
 add_local_lib_path()
@@ -125,12 +126,26 @@ class CinderServiceStatusDataSourcePlugin(PythonDataSourcePlugin):
         results = {}
 
         log.debug('Requesting services')
-        result = yield cinder.services()
-        results['services'] = result['services']
-
-        yield self.preprocess_hosts(config, results)
-
-        defer.returnValue(results)
+        # ---------------------------------------------------------------------
+        # ZPS-5043
+        # Skip over API errors if user has restricted access, else raise.
+        # ---------------------------------------------------------------------
+        try:
+            result = yield cinder.services()
+        except APIClientError as ex:
+            if "403 Forbidden" in ex.message:
+                log.debug("OpenStack API: user lacks access to call: cinder.services.")
+                defer.returnValue(results)
+            else:
+                log.warning("OpenStack API: access issue: {}".format(ex))
+                raise
+        except Exception as ex:
+            log.error("OpenStack API Error: {}".format(ex))
+            raise
+        else:
+            results['services'] = result['services']
+            yield self.preprocess_hosts(config, results)
+            defer.returnValue(results)
 
     @inlineCallbacks
     def preprocess_hosts(self, config, results):
@@ -184,7 +199,7 @@ class CinderServiceStatusDataSourcePlugin(PythonDataSourcePlugin):
     def onSuccess(self, result, config):
         data = self.new_data()
 
-        for service in result['services']:
+        for service in result.get('services', {}):
             host_id = service['host']
             hostname = result['hostmap'].get_hostname_for_hostid(host_id)
             host_base_id = re.sub(r'^host-', '', host_id)

--- a/ZenPacks/zenoss/OpenStackInfrastructure/datasources/NeutronAgentStatusDataSource.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/datasources/NeutronAgentStatusDataSource.py
@@ -18,12 +18,13 @@ from zope.interface import implements
 
 from Products.DataCollector.plugins.DataMaps import ObjectMap
 from Products.ZenEvents import ZenEventClasses
+from Products.ZenUtils.Utils import prepId
 
 from ZenPacks.zenoss.PythonCollector.datasources.PythonDataSource import (
     PythonDataSource, PythonDataSourcePlugin, PythonDataSourceInfo,
     IPythonDataSourceInfo)
 
-from Products.ZenUtils.Utils import prepId
+from ZenPacks.zenoss.OpenStackInfrastructure.apiclients.exceptions import APIClientError
 from ZenPacks.zenoss.OpenStackInfrastructure.utils import result_errmsg, add_local_lib_path
 add_local_lib_path()
 
@@ -118,15 +119,30 @@ class NeutronAgentStatusDataSourcePlugin(PythonDataSourcePlugin):
         results = {}
 
         log.debug('Requesting agent-list')
-        result = yield neutron.agents()
-        results['agents'] = result['agents']
-
-        defer.returnValue(results)
+        # ---------------------------------------------------------------------
+        # ZPS-5043
+        # Skip over API errors if user has restricted access, else raise.
+        # ---------------------------------------------------------------------
+        try:
+            result = yield neutron.agents()
+        except APIClientError as ex:
+            if "403 Forbidden" in ex.message:
+                log.debug("OpenStack API: user lacks access to call: neutron.agents.")
+                defer.returnValue(results)
+            else:
+                log.warning("OpenStack API: access issue: {}".format(ex))
+                raise
+        except Exception as ex:
+            log.error("OpenStack API Error: {}".format(ex))
+            raise
+        else:
+            results['agents'] = result['agents']
+            defer.returnValue(results)
 
     def onSuccess(self, result, config):
         data = self.new_data()
 
-        for agent in result['agents']:
+        for agent in result.get('agents', {}):
             agent_id = prepId('agent-{0}'.format(agent['id']))
 
             data['maps'].append(ObjectMap(

--- a/ZenPacks/zenoss/OpenStackInfrastructure/modeler/plugins/zenoss/OpenStackInfrastructure.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/modeler/plugins/zenoss/OpenStackInfrastructure.py
@@ -1658,18 +1658,19 @@ class OpenStackInfrastructure(PythonPlugin):
         results['host_mappings'] = hostmap.freeze_mappings()
 
     def replace_hosts_with_ids(self, hostmap, results):
-        # replace all references to hosts in results with their host IDs,
-        # using the information in the hostmap object.
+        # Replace all references to hosts in results with their host IDs,
+        #  using the information in the hostmap object.
+        # ZPS-5043: Guard against missing items due to restricted users.
 
-        for service in results['services']:
+        for service in results.get('services', {}):
             if 'host' in service:
                 service['host'] = hostmap.get_hostid(service['host'])
 
-        for agent in results['agents']:
+        for agent in results.get('agents', {}):
             if 'host' in agent:
                 agent['host'] = hostmap.get_hostid(agent['host'])
 
-        for service in results['cinder_services']:
+        for service in results.get('cinder_services', {}):
             if 'host' in service:
                 if hostmap.has_hostref(service['host']):
                     service['host'] = hostmap.get_hostid(service['host'])

--- a/docs/body.md
+++ b/docs/body.md
@@ -424,14 +424,26 @@ Restricted (non-administrator) users can also model and monitor OpenStack
 devices, with access to those devices consistent with that user's privileges.
 In other words, you should expect reduced visiblity for restricted users.
 
-In particular, a restricted user will see:
+A restricted should expect to see:
 
 * Fewer modeled components
 * Reduced monitored metrics
 * Absent events for missing components
 
+In particular, restricted users can see diminished components and metrics for:
+
+* Cinder Pools
+* Cinder Services
+* Cinder Volumes
+* Hypervisors
+* Neutron Agents
+* Nova Services 
+* Tenants
+* Any API item that requires administrator access
+
 If you believe a user should have more access to data, it is your responsibity
 to adjust the user's access level on OpenStack.
+
 
 Domain Support
 ---------------------


### PR DESCRIPTION
Fixes ZPS-5043

* Baby-proof commands in datasources that may be restricted.
* Fix modeler error that can throw events: only shows in events.
* The above fixes should allow green status for resticted users.