### PR TITLE
Fix error when zOpenStackCinderApiHosts is used

### DIFF
--- a/ZenPacks/zenoss/OpenStackInfrastructure/modeler/plugins/zenoss/OpenStackInfrastructure.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/modeler/plugins/zenoss/OpenStackInfrastructure.py
@@ -1616,6 +1616,9 @@ class OpenStackInfrastructure(PythonPlugin):
         for hostname in results['zOpenStackNovaApiHosts']:
             hostmap.add_hostref(hostname, source="zOpenStackNovaApiHosts")
 
+        for hostname in results['zOpenStackCinderApiHosts']:
+            hostmap.add_hostref(hostname, source="zOpenStackCinderApiHosts")
+
         for hostname in results['zOpenStackExtraHosts']:
             hostmap.add_hostref(hostname, source="zOpenStackExtraHosts")
 
@@ -1679,6 +1682,9 @@ class OpenStackInfrastructure(PythonPlugin):
 
         results['zOpenStackNovaApiHosts'] = \
             [hostmap.get_hostid(x) for x in results['zOpenStackNovaApiHosts']]
+
+        results['zOpenStackCinderApiHosts'] = \
+            [hostmap.get_hostid(x) for x in results['zOpenStackCinderApiHosts']]
 
         results['zOpenStackExtraHosts'] = \
             [hostmap.get_hostid(x) for x in results['zOpenStackExtraHosts']]

--- a/ZenPacks/zenoss/OpenStackInfrastructure/tests/test_hostmap.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/tests/test_hostmap.py
@@ -170,7 +170,6 @@ class TestHostMap(BaseTestCase):
         # We want this to consolidated into one hostid.
         self.assertEquals(len(hostmap.all_hostids()), 1)
 
-
     def test_case_insensitve_assert_host_id(self):
         hostmap = HostMap()
         hostmap.add_hostref("Test1")
@@ -178,6 +177,7 @@ class TestHostMap(BaseTestCase):
         self.perform_mapping(hostmap)
         self.assertEquals(hostmap.get_hostid("test1"), "host-test1-forcedid")
         self.assertEquals(hostmap.get_hostid("Test1"), "host-test1-forcedid")
+
 
 def test_suite():
     from unittest import TestSuite, makeSuite

--- a/ZenPacks/zenoss/OpenStackInfrastructure/tests/test_model_process_base.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/tests/test_model_process_base.py
@@ -13,7 +13,7 @@
 #
 ###########################################################################
 
-from collections import Counter
+from collections import Counter, defaultdict
 import os
 import json
 import logging
@@ -830,6 +830,38 @@ class TestModelProcess(BaseTestCase):
         for objmap in all_objmaps(self._processTestData(data)):
             if getattr(objmap, 'id', None) == server_id:
                 self.assertFalse(hasattr(objmap, 'set_image'))
+
+    def test_zOpenStackNovaApiHosts(self):
+        data = self.data.copy()
+        data['zOpenStackNovaApiHosts'] = ['novaapi1.myhost.com', 'novaapi2.myhost.com']
+
+        objects = defaultdict(dict)
+        for om in all_objmaps(self._processTestData(data)):
+            object_type = om.modname.replace("ZenPacks.zenoss.OpenStackInfrastructure.", "")
+            object_id = getattr(om, 'id', None)
+            om_dict = {k: v for k, v in om.__dict__.iteritems() if k != '_attrs'}
+            objects[object_type][object_id] = om_dict
+
+        self.assertEquals(len(objects['NovaApi']), 3)
+        self.assertEquals(len(objects['CinderApi']), 1)
+        self.assertIn('host-novaapi1.myhost.com', objects['Host'].keys())
+        self.assertIn('host-novaapi2.myhost.com', objects['Host'].keys())
+
+    def test_zOpenStackCinderApiHosts(self):
+        data = self.data.copy()
+        data['zOpenStackCinderApiHosts'] = ['cinderapi1.myhost.com', 'cinderapi2.myhost.com']
+
+        objects = defaultdict(dict)
+        for om in all_objmaps(self._processTestData(data)):
+            object_type = om.modname.replace("ZenPacks.zenoss.OpenStackInfrastructure.", "")
+            object_id = getattr(om, 'id', None)
+            om_dict = {k: v for k, v in om.__dict__.iteritems() if k != '_attrs'}
+            objects[object_type][object_id] = om_dict
+
+        self.assertEquals(len(objects['NovaApi']), 1)
+        self.assertEquals(len(objects['CinderApi']), 3)
+        self.assertIn('host-cinderapi1.myhost.com', objects['Host'].keys())
+        self.assertIn('host-cinderapi2.myhost.com', objects['Host'].keys())
 
 
 def test_suite():


### PR DESCRIPTION
- Pass zOpenStackCinderApiHosts through hostmap
- Add unit tests for zOpenStackCinderApiHosts and zOpenStackNovaApiHosts