### PR TITLE
ZPS-5458: Newly deployed RabbitMQ-Ceilometer service fails to start, with no_such_vhost,<<"/">> error

### DIFF
--- a/ZenPacks/zenoss/OpenStackInfrastructure/libexec/init_rabbitmq-ceil.sh
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/libexec/init_rabbitmq-ceil.sh
@@ -3,6 +3,12 @@
 set -e
 SENTINEL=/tmp/rabbit_ceil_ok
 if [ ! -e $SENTINEL ] ; then
+
+    # allow time for rabbitmq to initialize the first time it is run.  Try
+    # to avoid triggering this bug in rabbitMQ prior to 3.4.0:
+    # https://github.com/rabbitmq/rabbitmq-server/commit/5567b10f6
+    sleep 45
+
     USER=$1
     PASSWORD=$2
     #Tag with administrator in order to add ability to create and delete users, create and delete permissions through http api


### PR DESCRIPTION
Attempt to work around a possible race condition by adding a time delay.
Also lower severity of some log messages during zenpack upgrade to make it a bit less verbose