### PR TITLE
Release 4.0.0 Openstack Queens and Trains Modeled

### DIFF
--- a/ZenPacks/zenoss/OpenStackInfrastructure/zenopenstack.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/zenopenstack.py
@@ -503,7 +503,7 @@ class Health(Resource):
                 body += "  <td>None</td>"
             body += "  <td><a href=\"/health/logs/%s%s\">request log</a></td>" % (client_ip, uri)
             body += "</tr>"
-
+            
         return body + """
     </table>
 

--- a/src/txsshclient-1.0.0/setup.py
+++ b/src/txsshclient-1.0.0/setup.py
@@ -22,7 +22,11 @@ def get_version(filename):
 requires = [
     'twisted',
     'pyasn1',
-    'PyCrypto'
+    'PyCrypto',
+]
+install_requires = [
+    'idna<=2.10,>=2.4',
+    'twisted<21',
 ]
 
 setup(
@@ -52,7 +56,6 @@ setup(
     url='http://github.com/zenoss/txsshclient',
     license='All Rights Reserved',
     requires=requires,
-    setup_requires=requires,
-    install_requires=requires,
+    install_requires=install_requires,
 )
 


### PR DESCRIPTION
Openstack Queens & RTrain Modeling confirmed - RELEASE 4.0.0 [ For Openstack Infrastructure Monitoring ] 

- Changes Tracked ( Panko Events missing in current Release for Openstack Train  )
- CPU Util , READ/WRITE IO metrics missing for TRAIN/QUEEN ( since API deprecated )  

Release 4.0.0 ready to be deployed to develop.
