### PR TITLE
Fix RabbitMQ-Ceilometer failed healthchecks on 7.2

### DIFF
--- a/ZenPacks/zenoss/OpenStackInfrastructure/__init__.py
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/__init__.py
@@ -69,6 +69,10 @@ class ZenPack(schema.ZenPack):
             # We ship a shell script as a "config" file- make sure that
             # the config is updated if the script has changed.
             force_update_configs(self, "proxy-zenopenstack", ["opt/zenoss/bin/proxy-zenopenstack"])
+            # Starting from CZ 7.2.0/ZSD 6.8.0 we have to replace the old rabbitmq-env.conf
+            # because of OS and RabbitMQ version changes. These changes are backward
+            # compatible with pre CZ 7.2.0/ZSD 6.8.0 platform versions.
+            force_update_configs(self, "RabbitMQ-Ceilometer", ["etc/rabbitmq/rabbitmq-env.conf"])
 
     def getServiceDefinitionFiles(self):
         # The default version of this is only called during initial installation,

--- a/ZenPacks/zenoss/OpenStackInfrastructure/service_definition/-CONFIGS-/etc/rabbitmq/rabbitmq-env.conf
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/service_definition/-CONFIGS-/etc/rabbitmq/rabbitmq-env.conf
@@ -1,5 +1,5 @@
 NODENAME=rabbit@rbt-ceil{{.InstanceID}}
 NODE_IP_ADDRESS=0.0.0.0
 RABBITMQ_MNESIA_BASE=/var/lib/rabbitmq/mnesia-ceil-{{(parent .).Name}}{{if ne .InstanceID 0}}-node{{end}}
-RABBITMQ_NODE_PORT=55672
+RABBITMQ_DIST_PORT=55672
 


### PR DESCRIPTION
Fixes ZPS-8936.

Changed RABBITMQ_NODE_PORT env variable to RABBITMQ_DIST_PORT in the rabbitmq-env.conf. Added a migration for configs.